### PR TITLE
Fix Bug in the ami download files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,13 @@ requires = ["hatchling"]
 [project]
 authors = [{name = "Wordcab"}]
 classifiers = [
+  "Topic :: Internet",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.8",

--- a/src/rtasr/datasets/dataset_ami.py
+++ b/src/rtasr/datasets/dataset_ami.py
@@ -265,6 +265,8 @@ async def _create_manifest(
         raise Exception(
             f"Number of audio files ({len(audio_files)}), rttm files"
             f" ({len(rttm_files)}) and uem files ({len(uem_files)}) do not match."
+            " Please check the dataset folder, there might be some extra or missing"
+            " files."
         )
 
     if manifest_filepath.exists():

--- a/src/rtasr/utils.py
+++ b/src/rtasr/utils.py
@@ -115,7 +115,9 @@ async def download_file(
         Path to output file.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / Path(url).name
+
+    _output_file = output_dir / Path(url).name
+    output_file = _filename_dots_filter(_output_file)
 
     if use_cache and output_file.exists():
         return output_file
@@ -213,3 +215,21 @@ async def unzip_file(zip_path: Path, output_dir: Path, use_cache: bool = True) -
 def resolve_cache_dir() -> Path:
     """Resolve the cache directory for rtasr."""
     return Path.home() / ".cache" / "rtasr"
+
+
+def _filename_dots_filter(file_path: Path) -> Path:
+    """
+    Filter dots in the filename to avoid issues with API calls.
+
+    Args:
+        file_path (Path):
+            Path to file.
+
+    Returns:
+        Path to file with dots replaced with underscores.
+    """
+    filename = file_path.name
+    new_filename = filename.replace(".", "_", filename.count(".") - 1)
+    new_file_path = file_path.with_name(new_filename)
+
+    return new_file_path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 import rich
 
 from rtasr.utils import (
+    _filename_dots_filter,
     build_query_string,
     create_live_panel,
     get_api_key,
@@ -142,6 +143,20 @@ class TestUtilsModule:
         result = await unzip_file(zip_path, output_dir)
         assert result == output_subdir
         assert output_subdir.exists()
+
+    @pytest.mark.parametrize(
+        ["filename", "expected"],
+        [
+            ("file_name.txt", "file_name.txt"),
+            ("file.name.txt", "file_name.txt"),
+            ("file.name.txt.txt", "file_name_txt.txt"),
+            ("file.name.txt.txt.txt", "file_name_txt_txt.txt"),
+        ],
+    )
+    def test_filename_dots_filter(self, filename, expected) -> None:
+        """Test the _filename_dots_filter function."""
+        result = _filename_dots_filter(Path(filename))
+        assert str(result) == expected
 
     # @pytest.mark.asyncio
     # @pytest.mark.usefixtures("mock_response")


### PR DESCRIPTION
## ✨ Features

* Add some classifiers to the `pyproject.toml` file.

## 🐛 Bug Fixes

* Fix the AMI dataset file names to avoid bugs when using the files for API calls.  Extra dots were failing the API requests.

## 🔗 Linked Issue/s

Fixes #21 
Fixes #19 

## 🧪 Tests

- [x] Did you implement unit tests if required?

Tests added for the new `_filename_dots_filter` method.