### PR TITLE
AsrOutputs + Wordcab to RTTM

### DIFF
--- a/data/assemblyai_sample.json
+++ b/data/assemblyai_sample.json
@@ -1,0 +1,1416 @@
+{
+    "id": "6tn2ww4gkw-5b1d-45e3-905a-2916f43b896a",
+    "language_model": "assemblyai_default",
+    "acoustic_model": "assemblyai_default",
+    "language_code": "en_us",
+    "status": "completed",
+    "audio_url": "https://cdn.assemblyai.com/upload/c73eb1ff-a700-4976-8ce3-00b84a9b01e9",
+    "text": "CNN has decided not to run a Donald Trump endorsed campaign ad after the network decided it does not meet their standards. The 32nd advertisement paid for by Trump's campaign targeted Joe Biden's conduct toward Ukraine while he served as vice president, while also referring to CNN personalities Don Lemon, Chris Cuomo and Jim Acosta as media lapdogs. A CNN spokesperson spoke to THR, saying the ad does not meet the network's advertising standards, adding, in addition to disparaging CNN and its journalists, the ad makes assertions that have been proven demonstrably false by various news outlets, including CNN. However, despite CNN's rejection, the president posted the advertisement onto his Twitter page last week, along with the caption, I am draining the swamp now. This is not the first time CNN has rejected a Trump campaign ad. Back in 2017, the Net refused to run a Trump approved ad called Let President Trump Do His Job, which criticized the media and specifically called out Lemon as well as Anderson Cooper. To stay up to date on this story, head to THR.com and until next time for The Hollywood Reporter News, I'm a hajoy.",
+    "words": [
+        {
+            "text": "CNN",
+            "start": 410,
+            "end": 794,
+            "confidence": 0.94134,
+            "speaker": null
+        },
+        {
+            "text": "has",
+            "start": 842,
+            "end": 1054,
+            "confidence": 0.99993,
+            "speaker": null
+        },
+        {
+            "text": "decided",
+            "start": 1092,
+            "end": 1402,
+            "confidence": 0.99952,
+            "speaker": null
+        },
+        {
+            "text": "not",
+            "start": 1466,
+            "end": 1646,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 1668,
+            "end": 1806,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "run",
+            "start": 1828,
+            "end": 2014,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "a",
+            "start": 2052,
+            "end": 2206,
+            "confidence": 0.8,
+            "speaker": null
+        },
+        {
+            "text": "Donald",
+            "start": 2228,
+            "end": 2506,
+            "confidence": 0.99824,
+            "speaker": null
+        },
+        {
+            "text": "Trump",
+            "start": 2538,
+            "end": 2782,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "endorsed",
+            "start": 2836,
+            "end": 3258,
+            "confidence": 0.89729,
+            "speaker": null
+        },
+        {
+            "text": "campaign",
+            "start": 3274,
+            "end": 3674,
+            "confidence": 0.99971,
+            "speaker": null
+        },
+        {
+            "text": "ad",
+            "start": 3722,
+            "end": 4030,
+            "confidence": 0.60757,
+            "speaker": null
+        },
+        {
+            "text": "after",
+            "start": 4100,
+            "end": 4334,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 4372,
+            "end": 4526,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "network",
+            "start": 4548,
+            "end": 4826,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "decided",
+            "start": 4858,
+            "end": 5242,
+            "confidence": 0.35674,
+            "speaker": null
+        },
+        {
+            "text": "it",
+            "start": 5306,
+            "end": 5534,
+            "confidence": 0.97365,
+            "speaker": null
+        },
+        {
+            "text": "does",
+            "start": 5572,
+            "end": 5726,
+            "confidence": 0.99994,
+            "speaker": null
+        },
+        {
+            "text": "not",
+            "start": 5748,
+            "end": 5886,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "meet",
+            "start": 5908,
+            "end": 6094,
+            "confidence": 0.99994,
+            "speaker": null
+        },
+        {
+            "text": "their",
+            "start": 6132,
+            "end": 6334,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "standards.",
+            "start": 6372,
+            "end": 7230,
+            "confidence": 0.99911,
+            "speaker": null
+        },
+        {
+            "text": "The",
+            "start": 8450,
+            "end": 8814,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "32nd",
+            "start": 8852,
+            "end": 9342,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "advertisement",
+            "start": 9396,
+            "end": 10074,
+            "confidence": 0.99913,
+            "speaker": null
+        },
+        {
+            "text": "paid",
+            "start": 10122,
+            "end": 10334,
+            "confidence": 0.9999,
+            "speaker": null
+        },
+        {
+            "text": "for",
+            "start": 10372,
+            "end": 10574,
+            "confidence": 0.89475,
+            "speaker": null
+        },
+        {
+            "text": "by",
+            "start": 10612,
+            "end": 10766,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "Trump's",
+            "start": 10788,
+            "end": 11146,
+            "confidence": 0.96258,
+            "speaker": null
+        },
+        {
+            "text": "campaign",
+            "start": 11178,
+            "end": 11690,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "targeted",
+            "start": 11770,
+            "end": 12266,
+            "confidence": 0.98922,
+            "speaker": null
+        },
+        {
+            "text": "Joe",
+            "start": 12298,
+            "end": 12506,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "Biden's",
+            "start": 12538,
+            "end": 12986,
+            "confidence": 0.99654,
+            "speaker": null
+        },
+        {
+            "text": "conduct",
+            "start": 13018,
+            "end": 13386,
+            "confidence": 0.87572,
+            "speaker": null
+        },
+        {
+            "text": "toward",
+            "start": 13418,
+            "end": 13674,
+            "confidence": 0.8416,
+            "speaker": null
+        },
+        {
+            "text": "Ukraine",
+            "start": 13722,
+            "end": 14250,
+            "confidence": 0.99414,
+            "speaker": null
+        },
+        {
+            "text": "while",
+            "start": 14330,
+            "end": 14526,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "he",
+            "start": 14548,
+            "end": 14686,
+            "confidence": 0.99996,
+            "speaker": null
+        },
+        {
+            "text": "served",
+            "start": 14708,
+            "end": 14986,
+            "confidence": 0.60004,
+            "speaker": null
+        },
+        {
+            "text": "as",
+            "start": 15018,
+            "end": 15214,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "vice",
+            "start": 15252,
+            "end": 15466,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "president,",
+            "start": 15498,
+            "end": 15934,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "while",
+            "start": 16052,
+            "end": 16334,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "also",
+            "start": 16372,
+            "end": 16574,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "referring",
+            "start": 16612,
+            "end": 17018,
+            "confidence": 0.59055,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 17034,
+            "end": 17166,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "CNN",
+            "start": 17188,
+            "end": 17594,
+            "confidence": 0.94722,
+            "speaker": null
+        },
+        {
+            "text": "personalities",
+            "start": 17642,
+            "end": 18282,
+            "confidence": 0.99989,
+            "speaker": null
+        },
+        {
+            "text": "Don",
+            "start": 18346,
+            "end": 18574,
+            "confidence": 0.99971,
+            "speaker": null
+        },
+        {
+            "text": "Lemon,",
+            "start": 18612,
+            "end": 19130,
+            "confidence": 0.91661,
+            "speaker": null
+        },
+        {
+            "text": "Chris",
+            "start": 19210,
+            "end": 19466,
+            "confidence": 0.99962,
+            "speaker": null
+        },
+        {
+            "text": "Cuomo",
+            "start": 19498,
+            "end": 20074,
+            "confidence": 0.99788,
+            "speaker": null
+        },
+        {
+            "text": "and",
+            "start": 20122,
+            "end": 20382,
+            "confidence": 0.68,
+            "speaker": null
+        },
+        {
+            "text": "Jim",
+            "start": 20436,
+            "end": 20666,
+            "confidence": 0.99925,
+            "speaker": null
+        },
+        {
+            "text": "Acosta",
+            "start": 20698,
+            "end": 21194,
+            "confidence": 0.99674,
+            "speaker": null
+        },
+        {
+            "text": "as",
+            "start": 21242,
+            "end": 21406,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "media",
+            "start": 21428,
+            "end": 21710,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "lapdogs.",
+            "start": 21780,
+            "end": 22698,
+            "confidence": 0.7045,
+            "speaker": null
+        },
+        {
+            "text": "A",
+            "start": 22794,
+            "end": 22958,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "CNN",
+            "start": 22964,
+            "end": 23354,
+            "confidence": 0.92053,
+            "speaker": null
+        },
+        {
+            "text": "spokesperson",
+            "start": 23402,
+            "end": 24026,
+            "confidence": 0.9998,
+            "speaker": null
+        },
+        {
+            "text": "spoke",
+            "start": 24058,
+            "end": 24298,
+            "confidence": 0.99991,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 24314,
+            "end": 24446,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "THR,",
+            "start": 24468,
+            "end": 24918,
+            "confidence": 0.99,
+            "speaker": null
+        },
+        {
+            "text": "saying",
+            "start": 25044,
+            "end": 25334,
+            "confidence": 0.99703,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 25372,
+            "end": 25526,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "ad",
+            "start": 25548,
+            "end": 25782,
+            "confidence": 0.99958,
+            "speaker": null
+        },
+        {
+            "text": "does",
+            "start": 25836,
+            "end": 26006,
+            "confidence": 0.99927,
+            "speaker": null
+        },
+        {
+            "text": "not",
+            "start": 26028,
+            "end": 26166,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "meet",
+            "start": 26188,
+            "end": 26374,
+            "confidence": 0.99986,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 26412,
+            "end": 26518,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "network's",
+            "start": 26524,
+            "end": 26946,
+            "confidence": 0.99745,
+            "speaker": null
+        },
+        {
+            "text": "advertising",
+            "start": 26978,
+            "end": 27554,
+            "confidence": 0.99862,
+            "speaker": null
+        },
+        {
+            "text": "standards,",
+            "start": 27602,
+            "end": 28114,
+            "confidence": 0.9991,
+            "speaker": null
+        },
+        {
+            "text": "adding,",
+            "start": 28162,
+            "end": 28690,
+            "confidence": 0.99828,
+            "speaker": null
+        },
+        {
+            "text": "in",
+            "start": 28770,
+            "end": 28966,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "addition",
+            "start": 28988,
+            "end": 29186,
+            "confidence": 0.94325,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 29218,
+            "end": 29414,
+            "confidence": 0.92,
+            "speaker": null
+        },
+        {
+            "text": "disparaging",
+            "start": 29452,
+            "end": 29986,
+            "confidence": 0.99942,
+            "speaker": null
+        },
+        {
+            "text": "CNN",
+            "start": 30018,
+            "end": 30514,
+            "confidence": 0.98442,
+            "speaker": null
+        },
+        {
+            "text": "and",
+            "start": 30562,
+            "end": 30726,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "its",
+            "start": 30748,
+            "end": 30886,
+            "confidence": 0.99995,
+            "speaker": null
+        },
+        {
+            "text": "journalists,",
+            "start": 30908,
+            "end": 31490,
+            "confidence": 0.5385,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 31570,
+            "end": 31766,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "ad",
+            "start": 31788,
+            "end": 31926,
+            "confidence": 0.99973,
+            "speaker": null
+        },
+        {
+            "text": "makes",
+            "start": 31948,
+            "end": 32182,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "assertions",
+            "start": 32236,
+            "end": 32626,
+            "confidence": 0.99814,
+            "speaker": null
+        },
+        {
+            "text": "that",
+            "start": 32658,
+            "end": 32806,
+            "confidence": 0.99972,
+            "speaker": null
+        },
+        {
+            "text": "have",
+            "start": 32828,
+            "end": 32966,
+            "confidence": 0.99995,
+            "speaker": null
+        },
+        {
+            "text": "been",
+            "start": 32988,
+            "end": 33078,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "proven",
+            "start": 33084,
+            "end": 33426,
+            "confidence": 0.99996,
+            "speaker": null
+        },
+        {
+            "text": "demonstrably",
+            "start": 33458,
+            "end": 34146,
+            "confidence": 0.49829,
+            "speaker": null
+        },
+        {
+            "text": "false",
+            "start": 34178,
+            "end": 34546,
+            "confidence": 0.99967,
+            "speaker": null
+        },
+        {
+            "text": "by",
+            "start": 34578,
+            "end": 34726,
+            "confidence": 0.99994,
+            "speaker": null
+        },
+        {
+            "text": "various",
+            "start": 34748,
+            "end": 35074,
+            "confidence": 0.99983,
+            "speaker": null
+        },
+        {
+            "text": "news",
+            "start": 35122,
+            "end": 35382,
+            "confidence": 0.99989,
+            "speaker": null
+        },
+        {
+            "text": "outlets,",
+            "start": 35436,
+            "end": 35922,
+            "confidence": 0.99623,
+            "speaker": null
+        },
+        {
+            "text": "including",
+            "start": 35986,
+            "end": 36386,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "CNN.",
+            "start": 36418,
+            "end": 37010,
+            "confidence": 0.92512,
+            "speaker": null
+        },
+        {
+            "text": "However,",
+            "start": 37090,
+            "end": 37382,
+            "confidence": 0.99995,
+            "speaker": null
+        },
+        {
+            "text": "despite",
+            "start": 37436,
+            "end": 37826,
+            "confidence": 0.99945,
+            "speaker": null
+        },
+        {
+            "text": "CNN's",
+            "start": 37858,
+            "end": 38338,
+            "confidence": 0.99936,
+            "speaker": null
+        },
+        {
+            "text": "rejection,",
+            "start": 38354,
+            "end": 38786,
+            "confidence": 0.90986,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 38818,
+            "end": 38966,
+            "confidence": 0.75,
+            "speaker": null
+        },
+        {
+            "text": "president",
+            "start": 38988,
+            "end": 39318,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "posted",
+            "start": 39404,
+            "end": 39746,
+            "confidence": 0.99926,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 39778,
+            "end": 39926,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "advertisement",
+            "start": 39948,
+            "end": 40466,
+            "confidence": 0.97861,
+            "speaker": null
+        },
+        {
+            "text": "onto",
+            "start": 40498,
+            "end": 40738,
+            "confidence": 0.99959,
+            "speaker": null
+        },
+        {
+            "text": "his",
+            "start": 40754,
+            "end": 40886,
+            "confidence": 0.98748,
+            "speaker": null
+        },
+        {
+            "text": "Twitter",
+            "start": 40908,
+            "end": 41266,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "page",
+            "start": 41298,
+            "end": 41542,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "last",
+            "start": 41596,
+            "end": 41862,
+            "confidence": 0.99995,
+            "speaker": null
+        },
+        {
+            "text": "week,",
+            "start": 41916,
+            "end": 42278,
+            "confidence": 0.99996,
+            "speaker": null
+        },
+        {
+            "text": "along",
+            "start": 42364,
+            "end": 42566,
+            "confidence": 0.99994,
+            "speaker": null
+        },
+        {
+            "text": "with",
+            "start": 42588,
+            "end": 42726,
+            "confidence": 0.99502,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 42748,
+            "end": 42886,
+            "confidence": 0.98,
+            "speaker": null
+        },
+        {
+            "text": "caption,",
+            "start": 42908,
+            "end": 43314,
+            "confidence": 0.9998,
+            "speaker": null
+        },
+        {
+            "text": "I",
+            "start": 43362,
+            "end": 43478,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "am",
+            "start": 43484,
+            "end": 43606,
+            "confidence": 0.93,
+            "speaker": null
+        },
+        {
+            "text": "draining",
+            "start": 43628,
+            "end": 43986,
+            "confidence": 0.99967,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 44018,
+            "end": 44166,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "swamp",
+            "start": 44188,
+            "end": 44658,
+            "confidence": 0.99943,
+            "speaker": null
+        },
+        {
+            "text": "now.",
+            "start": 44754,
+            "end": 44966,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "This",
+            "start": 44988,
+            "end": 45126,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "is",
+            "start": 45148,
+            "end": 45286,
+            "confidence": 0.99978,
+            "speaker": null
+        },
+        {
+            "text": "not",
+            "start": 45308,
+            "end": 45494,
+            "confidence": 0.99991,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 45532,
+            "end": 45686,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "first",
+            "start": 45708,
+            "end": 45846,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "time",
+            "start": 45868,
+            "end": 46054,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "CNN",
+            "start": 46092,
+            "end": 46514,
+            "confidence": 0.99518,
+            "speaker": null
+        },
+        {
+            "text": "has",
+            "start": 46562,
+            "end": 46726,
+            "confidence": 0.99979,
+            "speaker": null
+        },
+        {
+            "text": "rejected",
+            "start": 46748,
+            "end": 47186,
+            "confidence": 0.99861,
+            "speaker": null
+        },
+        {
+            "text": "a",
+            "start": 47218,
+            "end": 47366,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "Trump",
+            "start": 47388,
+            "end": 47622,
+            "confidence": 0.99996,
+            "speaker": null
+        },
+        {
+            "text": "campaign",
+            "start": 47676,
+            "end": 48114,
+            "confidence": 0.99982,
+            "speaker": null
+        },
+        {
+            "text": "ad.",
+            "start": 48162,
+            "end": 48518,
+            "confidence": 0.99798,
+            "speaker": null
+        },
+        {
+            "text": "Back",
+            "start": 48604,
+            "end": 48854,
+            "confidence": 0.99993,
+            "speaker": null
+        },
+        {
+            "text": "in",
+            "start": 48892,
+            "end": 48998,
+            "confidence": 0.99581,
+            "speaker": null
+        },
+        {
+            "text": "2017,",
+            "start": 49004,
+            "end": 49634,
+            "confidence": 0.94,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 49682,
+            "end": 49798,
+            "confidence": 0.99,
+            "speaker": null
+        },
+        {
+            "text": "Net",
+            "start": 49804,
+            "end": 50094,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "refused",
+            "start": 50172,
+            "end": 50538,
+            "confidence": 0.9734,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 50554,
+            "end": 50686,
+            "confidence": 0.96,
+            "speaker": null
+        },
+        {
+            "text": "run",
+            "start": 50708,
+            "end": 50846,
+            "confidence": 0.9999,
+            "speaker": null
+        },
+        {
+            "text": "a",
+            "start": 50868,
+            "end": 51006,
+            "confidence": 0.87,
+            "speaker": null
+        },
+        {
+            "text": "Trump",
+            "start": 51028,
+            "end": 51262,
+            "confidence": 0.99779,
+            "speaker": null
+        },
+        {
+            "text": "approved",
+            "start": 51316,
+            "end": 51674,
+            "confidence": 0.99983,
+            "speaker": null
+        },
+        {
+            "text": "ad",
+            "start": 51722,
+            "end": 51982,
+            "confidence": 0.99931,
+            "speaker": null
+        },
+        {
+            "text": "called",
+            "start": 52036,
+            "end": 52398,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "Let",
+            "start": 52484,
+            "end": 52734,
+            "confidence": 0.99515,
+            "speaker": null
+        },
+        {
+            "text": "President",
+            "start": 52772,
+            "end": 53070,
+            "confidence": 0.85775,
+            "speaker": null
+        },
+        {
+            "text": "Trump",
+            "start": 53140,
+            "end": 53422,
+            "confidence": 0.99957,
+            "speaker": null
+        },
+        {
+            "text": "Do",
+            "start": 53476,
+            "end": 53694,
+            "confidence": 0.99975,
+            "speaker": null
+        },
+        {
+            "text": "His",
+            "start": 53732,
+            "end": 53886,
+            "confidence": 0.99982,
+            "speaker": null
+        },
+        {
+            "text": "Job,",
+            "start": 53908,
+            "end": 54238,
+            "confidence": 0.99982,
+            "speaker": null
+        },
+        {
+            "text": "which",
+            "start": 54324,
+            "end": 54574,
+            "confidence": 0.99963,
+            "speaker": null
+        },
+        {
+            "text": "criticized",
+            "start": 54612,
+            "end": 55066,
+            "confidence": 0.99678,
+            "speaker": null
+        },
+        {
+            "text": "the",
+            "start": 55098,
+            "end": 55246,
+            "confidence": 0.81,
+            "speaker": null
+        },
+        {
+            "text": "media",
+            "start": 55268,
+            "end": 55550,
+            "confidence": 0.99996,
+            "speaker": null
+        },
+        {
+            "text": "and",
+            "start": 55620,
+            "end": 55854,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "specifically",
+            "start": 55892,
+            "end": 56426,
+            "confidence": 0.99991,
+            "speaker": null
+        },
+        {
+            "text": "called",
+            "start": 56458,
+            "end": 56702,
+            "confidence": 0.9999,
+            "speaker": null
+        },
+        {
+            "text": "out",
+            "start": 56756,
+            "end": 56926,
+            "confidence": 0.99973,
+            "speaker": null
+        },
+        {
+            "text": "Lemon",
+            "start": 56948,
+            "end": 57306,
+            "confidence": 0.84393,
+            "speaker": null
+        },
+        {
+            "text": "as",
+            "start": 57338,
+            "end": 57486,
+            "confidence": 0.99987,
+            "speaker": null
+        },
+        {
+            "text": "well",
+            "start": 57508,
+            "end": 57646,
+            "confidence": 0.99997,
+            "speaker": null
+        },
+        {
+            "text": "as",
+            "start": 57668,
+            "end": 57806,
+            "confidence": 0.99964,
+            "speaker": null
+        },
+        {
+            "text": "Anderson",
+            "start": 57828,
+            "end": 58186,
+            "confidence": 0.95688,
+            "speaker": null
+        },
+        {
+            "text": "Cooper.",
+            "start": 58218,
+            "end": 58778,
+            "confidence": 0.77136,
+            "speaker": null
+        },
+        {
+            "text": "To",
+            "start": 58874,
+            "end": 59086,
+            "confidence": 0.93,
+            "speaker": null
+        },
+        {
+            "text": "stay",
+            "start": 59108,
+            "end": 59294,
+            "confidence": 0.99914,
+            "speaker": null
+        },
+        {
+            "text": "up",
+            "start": 59332,
+            "end": 59438,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 59444,
+            "end": 59566,
+            "confidence": 0.99,
+            "speaker": null
+        },
+        {
+            "text": "date",
+            "start": 59588,
+            "end": 59726,
+            "confidence": 0.99999,
+            "speaker": null
+        },
+        {
+            "text": "on",
+            "start": 59748,
+            "end": 59838,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "this",
+            "start": 59844,
+            "end": 59966,
+            "confidence": 0.96669,
+            "speaker": null
+        },
+        {
+            "text": "story,",
+            "start": 59988,
+            "end": 60222,
+            "confidence": 0.9997,
+            "speaker": null
+        },
+        {
+            "text": "head",
+            "start": 60276,
+            "end": 60398,
+            "confidence": 0.83299,
+            "speaker": null
+        },
+        {
+            "text": "to",
+            "start": 60404,
+            "end": 60526,
+            "confidence": 0.72,
+            "speaker": null
+        },
+        {
+            "text": "THR.com",
+            "start": 60548,
+            "end": 61662,
+            "confidence": 0.97,
+            "speaker": null
+        },
+        {
+            "text": "and",
+            "start": 61716,
+            "end": 61886,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "until",
+            "start": 61908,
+            "end": 62142,
+            "confidence": 0.99986,
+            "speaker": null
+        },
+        {
+            "text": "next",
+            "start": 62196,
+            "end": 62366,
+            "confidence": 0.99998,
+            "speaker": null
+        },
+        {
+            "text": "time",
+            "start": 62388,
+            "end": 62526,
+            "confidence": 0.99958,
+            "speaker": null
+        },
+        {
+            "text": "for",
+            "start": 62548,
+            "end": 62638,
+            "confidence": 0.99715,
+            "speaker": null
+        },
+        {
+            "text": "The",
+            "start": 62644,
+            "end": 62718,
+            "confidence": 1.0,
+            "speaker": null
+        },
+        {
+            "text": "Hollywood",
+            "start": 62724,
+            "end": 63066,
+            "confidence": 0.95332,
+            "speaker": null
+        },
+        {
+            "text": "Reporter",
+            "start": 63098,
+            "end": 63418,
+            "confidence": 0.99863,
+            "speaker": null
+        },
+        {
+            "text": "News,",
+            "start": 63434,
+            "end": 63614,
+            "confidence": 0.97517,
+            "speaker": null
+        },
+        {
+            "text": "I'm",
+            "start": 63652,
+            "end": 63866,
+            "confidence": 0.56933,
+            "speaker": null
+        },
+        {
+            "text": "a",
+            "start": 63898,
+            "end": 63998,
+            "confidence": 0.49,
+            "speaker": null
+        },
+        {
+            "text": "hajoy.",
+            "start": 64004,
+            "end": 64250,
+            "confidence": 0.3907,
+            "speaker": null
+        }
+    ],
+    "utterances": null,
+    "confidence": 0.9560385492227982,
+    "audio_duration": 68,
+    "punctuate": true,
+    "format_text": true,
+    "dual_channel": null,
+    "webhook_url": null,
+    "webhook_status_code": null,
+    "webhook_auth": false,
+    "webhook_auth_header_name": null,
+    "speed_boost": false,
+    "auto_highlights_result": null,
+    "auto_highlights": false,
+    "audio_start_from": null,
+    "audio_end_at": null,
+    "word_boost": [],
+    "boost_param": null,
+    "filter_profanity": false,
+    "redact_pii": false,
+    "redact_pii_audio": false,
+    "redact_pii_audio_quality": null,
+    "redact_pii_policies": null,
+    "redact_pii_sub": null,
+    "speaker_labels": false,
+    "content_safety": false,
+    "iab_categories": false,
+    "content_safety_labels": {
+        "status": "unavailable",
+        "results": [],
+        "summary": {}
+    },
+    "iab_categories_result": {
+        "status": "unavailable",
+        "results": [],
+        "summary": {}
+    },
+    "language_detection": false,
+    "custom_spelling": null,
+    "throttled": null,
+    "auto_chapters": false,
+    "summarization": false,
+    "summary_type": null,
+    "summary_model": null,
+    "custom_topics": false,
+    "topics": [],
+    "speech_threshold": null,
+    "disfluencies": false,
+    "sentiment_analysis": false,
+    "chapters": null,
+    "sentiment_analysis_results": null,
+    "entity_detection": false,
+    "entities": null,
+    "summary": null,
+    "speakers_expected": null
+}

--- a/data/deepgram_sample.json
+++ b/data/deepgram_sample.json
@@ -1,0 +1,3579 @@
+{
+    "metadata": {
+        "transaction_key": "deprecated",
+        "request_id": "54f607b2-1428-4d79-9124-27fb0cf19f21",
+        "sha256": "cadade53326e91918b482a41ab81817fc57bbaf35f809e5d7cc20e0c19d9ab2f",
+        "created": "2023-08-21T15:56:47.965Z",
+        "duration": 68.376,
+        "channels": 1,
+        "models": [
+            "aa274f3c-e8b3-456a-ac08-dfd797d45514"
+        ],
+        "model_info": {
+            "aa274f3c-e8b3-456a-ac08-dfd797d45514": {
+                "name": "general-nova",
+                "version": "2023-07-06.22746",
+                "arch": "nova"
+            }
+        }
+    },
+    "results": {
+        "channels": [
+            {
+                "alternatives": [
+                    {
+                        "transcript": "CNN has decided not to run a Donald Trump endorsed campaign ad after the network decided it does not meet their standards. The thirty second advertisement paid for by Trump's campaign targeted Joe Biden's conduct toward Ukraine while he served as vice president. While also referring to CNN personalities, Don Lemmon, Chris Cuomo, and Jim Acosta, as media lapdogs. A CNN spokesperson spoke to THR saying the ad does not meet the network's advertising standards adding. In addition to disparaging CNN and its journalists, the ad makes assertions that have been proven demonstrably false by various news outlets, including CNN. However, despite CNN's rejection, the president posted the advertisement onto his Twitter each last week, along with the caption, I'm draining the swamp. Now, this is not the first time CNN has rejected a Trump campaign ad. Back in twenty seventeen, the refused to run a Trump approved ad called let president Trump do his job, which criticized the media and specifically called out lemon as well as Anderson Cooper. To stay up to date on this story, hit the thr dot com, and until next time for the Hollywood reporter news, I may enjoy.",
+                        "confidence": 0.99560547,
+                        "words": [
+                            {
+                                "word": "cnn",
+                                "start": 0.24,
+                                "end": 0.71999997,
+                                "confidence": 0.73828125,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "CNN"
+                            },
+                            {
+                                "word": "has",
+                                "start": 0.71999997,
+                                "end": 0.88,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "has"
+                            },
+                            {
+                                "word": "decided",
+                                "start": 0.88,
+                                "end": 1.38,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "decided"
+                            },
+                            {
+                                "word": "not",
+                                "start": 1.4399999,
+                                "end": 1.68,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "not"
+                            },
+                            {
+                                "word": "to",
+                                "start": 1.68,
+                                "end": 1.8399999,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "to"
+                            },
+                            {
+                                "word": "run",
+                                "start": 1.8399999,
+                                "end": 2.08,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "run"
+                            },
+                            {
+                                "word": "a",
+                                "start": 2.08,
+                                "end": 2.1599998,
+                                "confidence": 0.95654297,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "a"
+                            },
+                            {
+                                "word": "donald",
+                                "start": 2.1599998,
+                                "end": 2.48,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "Donald"
+                            },
+                            {
+                                "word": "trump",
+                                "start": 2.48,
+                                "end": 2.72,
+                                "confidence": 0.99609375,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "Trump"
+                            },
+                            {
+                                "word": "endorsed",
+                                "start": 2.72,
+                                "end": 3.12,
+                                "confidence": 0.99316406,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "endorsed"
+                            },
+                            {
+                                "word": "campaign",
+                                "start": 3.12,
+                                "end": 3.62,
+                                "confidence": 0.9135742,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "campaign"
+                            },
+                            {
+                                "word": "ad",
+                                "start": 3.6799998,
+                                "end": 3.9199998,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "ad"
+                            },
+                            {
+                                "word": "after",
+                                "start": 3.9199998,
+                                "end": 4.24,
+                                "confidence": 0.9296875,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "after"
+                            },
+                            {
+                                "word": "the",
+                                "start": 4.24,
+                                "end": 4.4,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "network",
+                                "start": 4.4,
+                                "end": 4.7999997,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "network"
+                            },
+                            {
+                                "word": "decided",
+                                "start": 4.7999997,
+                                "end": 5.2799997,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "decided"
+                            },
+                            {
+                                "word": "it",
+                                "start": 5.2799997,
+                                "end": 5.52,
+                                "confidence": 0.9863281,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "it"
+                            },
+                            {
+                                "word": "does",
+                                "start": 5.52,
+                                "end": 5.68,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "does"
+                            },
+                            {
+                                "word": "not",
+                                "start": 5.68,
+                                "end": 5.92,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "not"
+                            },
+                            {
+                                "word": "meet",
+                                "start": 5.92,
+                                "end": 6.08,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "meet"
+                            },
+                            {
+                                "word": "their",
+                                "start": 6.08,
+                                "end": 6.3199997,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "their"
+                            },
+                            {
+                                "word": "standards",
+                                "start": 6.3199997,
+                                "end": 6.8199997,
+                                "confidence": 0.99194336,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8238818,
+                                "punctuated_word": "standards."
+                            },
+                            {
+                                "word": "the",
+                                "start": 8.565,
+                                "end": 8.724999,
+                                "confidence": 0.98291016,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "The"
+                            },
+                            {
+                                "word": "thirty",
+                                "start": 8.724999,
+                                "end": 9.045,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "thirty"
+                            },
+                            {
+                                "word": "second",
+                                "start": 9.045,
+                                "end": 9.445,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "second"
+                            },
+                            {
+                                "word": "advertisement",
+                                "start": 9.445,
+                                "end": 9.945,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "advertisement"
+                            },
+                            {
+                                "word": "paid",
+                                "start": 10.085,
+                                "end": 10.325,
+                                "confidence": 0.9248047,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "paid"
+                            },
+                            {
+                                "word": "for",
+                                "start": 10.325,
+                                "end": 10.565,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "for"
+                            },
+                            {
+                                "word": "by",
+                                "start": 10.565,
+                                "end": 10.725,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "by"
+                            },
+                            {
+                                "word": "trump's",
+                                "start": 10.725,
+                                "end": 11.125,
+                                "confidence": 0.98657227,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Trump's"
+                            },
+                            {
+                                "word": "campaign",
+                                "start": 11.125,
+                                "end": 11.625,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "campaign"
+                            },
+                            {
+                                "word": "targeted",
+                                "start": 11.764999,
+                                "end": 12.245,
+                                "confidence": 0.68896484,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "targeted"
+                            },
+                            {
+                                "word": "joe",
+                                "start": 12.245,
+                                "end": 12.485,
+                                "confidence": 0.9921875,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Joe"
+                            },
+                            {
+                                "word": "biden's",
+                                "start": 12.485,
+                                "end": 12.965,
+                                "confidence": 0.998291,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Biden's"
+                            },
+                            {
+                                "word": "conduct",
+                                "start": 12.965,
+                                "end": 13.365,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "conduct"
+                            },
+                            {
+                                "word": "toward",
+                                "start": 13.365,
+                                "end": 13.684999,
+                                "confidence": 0.9658203,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "toward"
+                            },
+                            {
+                                "word": "ukraine",
+                                "start": 13.684999,
+                                "end": 14.184999,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Ukraine"
+                            },
+                            {
+                                "word": "while",
+                                "start": 14.245,
+                                "end": 14.485,
+                                "confidence": 0.8154297,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "while"
+                            },
+                            {
+                                "word": "he",
+                                "start": 14.485,
+                                "end": 14.6449995,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "he"
+                            },
+                            {
+                                "word": "served",
+                                "start": 14.6449995,
+                                "end": 14.965,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "served"
+                            },
+                            {
+                                "word": "as",
+                                "start": 14.965,
+                                "end": 15.125,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "as"
+                            },
+                            {
+                                "word": "vice",
+                                "start": 15.125,
+                                "end": 15.445,
+                                "confidence": 0.9873047,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "vice"
+                            },
+                            {
+                                "word": "president",
+                                "start": 15.445,
+                                "end": 15.945,
+                                "confidence": 0.8586426,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "president."
+                            },
+                            {
+                                "word": "while",
+                                "start": 16.03,
+                                "end": 16.27,
+                                "confidence": 0.9868164,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "While"
+                            },
+                            {
+                                "word": "also",
+                                "start": 16.27,
+                                "end": 16.59,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "also"
+                            },
+                            {
+                                "word": "referring",
+                                "start": 16.59,
+                                "end": 16.99,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "referring"
+                            },
+                            {
+                                "word": "to",
+                                "start": 16.99,
+                                "end": 17.15,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "to"
+                            },
+                            {
+                                "word": "cnn",
+                                "start": 17.15,
+                                "end": 17.63,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "CNN"
+                            },
+                            {
+                                "word": "personalities",
+                                "start": 17.63,
+                                "end": 18.13,
+                                "confidence": 0.9086914,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "personalities,"
+                            },
+                            {
+                                "word": "don",
+                                "start": 18.35,
+                                "end": 18.59,
+                                "confidence": 0.9140625,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Don"
+                            },
+                            {
+                                "word": "lemmon",
+                                "start": 18.59,
+                                "end": 19.09,
+                                "confidence": 0.7232259,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Lemmon,"
+                            },
+                            {
+                                "word": "chris",
+                                "start": 19.23,
+                                "end": 19.47,
+                                "confidence": 0.98291016,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Chris"
+                            },
+                            {
+                                "word": "cuomo",
+                                "start": 19.47,
+                                "end": 19.97,
+                                "confidence": 0.89868164,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Cuomo,"
+                            },
+                            {
+                                "word": "and",
+                                "start": 20.189999,
+                                "end": 20.43,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "and"
+                            },
+                            {
+                                "word": "jim",
+                                "start": 20.43,
+                                "end": 20.67,
+                                "confidence": 0.9370117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Jim"
+                            },
+                            {
+                                "word": "acosta",
+                                "start": 20.67,
+                                "end": 21.17,
+                                "confidence": 0.8022461,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "Acosta,"
+                            },
+                            {
+                                "word": "as",
+                                "start": 21.23,
+                                "end": 21.39,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "as"
+                            },
+                            {
+                                "word": "media",
+                                "start": 21.39,
+                                "end": 21.789999,
+                                "confidence": 0.98291016,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "media"
+                            },
+                            {
+                                "word": "lapdogs",
+                                "start": 21.789999,
+                                "end": 22.289999,
+                                "confidence": 0.82161456,
+                                "speaker": 0,
+                                "speaker_confidence": 0.9041902,
+                                "punctuated_word": "lapdogs."
+                            },
+                            {
+                                "word": "a",
+                                "start": 22.75,
+                                "end": 22.91,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "A"
+                            },
+                            {
+                                "word": "cnn",
+                                "start": 22.91,
+                                "end": 23.41,
+                                "confidence": 0.9941406,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "CNN"
+                            },
+                            {
+                                "word": "spokesperson",
+                                "start": 23.47,
+                                "end": 23.97,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "spokesperson"
+                            },
+                            {
+                                "word": "spoke",
+                                "start": 24.029999,
+                                "end": 24.349998,
+                                "confidence": 0.9946289,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "spoke"
+                            },
+                            {
+                                "word": "to",
+                                "start": 24.349998,
+                                "end": 24.465,
+                                "confidence": 0.89941406,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "to"
+                            },
+                            {
+                                "word": "thr",
+                                "start": 24.465,
+                                "end": 24.965,
+                                "confidence": 0.6654053,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "THR"
+                            },
+                            {
+                                "word": "saying",
+                                "start": 25.025,
+                                "end": 25.265,
+                                "confidence": 0.5761719,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "saying"
+                            },
+                            {
+                                "word": "the",
+                                "start": 25.265,
+                                "end": 25.425,
+                                "confidence": 0.9824219,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "ad",
+                                "start": 25.425,
+                                "end": 25.745,
+                                "confidence": 0.9916992,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "ad"
+                            },
+                            {
+                                "word": "does",
+                                "start": 25.745,
+                                "end": 25.905,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "does"
+                            },
+                            {
+                                "word": "not",
+                                "start": 25.905,
+                                "end": 26.145,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "not"
+                            },
+                            {
+                                "word": "meet",
+                                "start": 26.145,
+                                "end": 26.385,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "meet"
+                            },
+                            {
+                                "word": "the",
+                                "start": 26.385,
+                                "end": 26.545,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "network's",
+                                "start": 26.545,
+                                "end": 26.945,
+                                "confidence": 0.97802734,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "network's"
+                            },
+                            {
+                                "word": "advertising",
+                                "start": 26.945,
+                                "end": 27.445,
+                                "confidence": 0.9868164,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "advertising"
+                            },
+                            {
+                                "word": "standards",
+                                "start": 27.585,
+                                "end": 28.065,
+                                "confidence": 0.9951172,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "standards"
+                            },
+                            {
+                                "word": "adding",
+                                "start": 28.065,
+                                "end": 28.565,
+                                "confidence": 0.7368164,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "adding."
+                            },
+                            {
+                                "word": "in",
+                                "start": 28.705,
+                                "end": 28.945,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "In"
+                            },
+                            {
+                                "word": "addition",
+                                "start": 28.945,
+                                "end": 29.265,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "addition"
+                            },
+                            {
+                                "word": "to",
+                                "start": 29.265,
+                                "end": 29.425,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "to"
+                            },
+                            {
+                                "word": "disparaging",
+                                "start": 29.425,
+                                "end": 29.925,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "disparaging"
+                            },
+                            {
+                                "word": "cnn",
+                                "start": 29.985,
+                                "end": 30.465,
+                                "confidence": 0.96484375,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "CNN"
+                            },
+                            {
+                                "word": "and",
+                                "start": 30.465,
+                                "end": 30.705,
+                                "confidence": 0.9863281,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "and"
+                            },
+                            {
+                                "word": "its",
+                                "start": 30.705,
+                                "end": 30.945,
+                                "confidence": 0.9921875,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "its"
+                            },
+                            {
+                                "word": "journalists",
+                                "start": 30.945,
+                                "end": 31.445,
+                                "confidence": 0.96875,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "journalists,"
+                            },
+                            {
+                                "word": "the",
+                                "start": 31.505001,
+                                "end": 31.665,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "ad",
+                                "start": 31.665,
+                                "end": 31.825,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "ad"
+                            },
+                            {
+                                "word": "makes",
+                                "start": 31.825,
+                                "end": 32.145,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "makes"
+                            },
+                            {
+                                "word": "assertions",
+                                "start": 32.145,
+                                "end": 32.625,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "assertions"
+                            },
+                            {
+                                "word": "that",
+                                "start": 32.625,
+                                "end": 32.785,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.86213976,
+                                "punctuated_word": "that"
+                            },
+                            {
+                                "word": "have",
+                                "start": 32.785,
+                                "end": 32.864998,
+                                "confidence": 0.9970703,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "have"
+                            },
+                            {
+                                "word": "been",
+                                "start": 32.864998,
+                                "end": 33.025,
+                                "confidence": 0.99609375,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "been"
+                            },
+                            {
+                                "word": "proven",
+                                "start": 33.025,
+                                "end": 33.505,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "proven"
+                            },
+                            {
+                                "word": "demonstrably",
+                                "start": 33.505,
+                                "end": 34.005,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "demonstrably"
+                            },
+                            {
+                                "word": "false",
+                                "start": 34.21,
+                                "end": 34.53,
+                                "confidence": 0.9082031,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "false"
+                            },
+                            {
+                                "word": "by",
+                                "start": 34.53,
+                                "end": 34.77,
+                                "confidence": 0.98828125,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "by"
+                            },
+                            {
+                                "word": "various",
+                                "start": 34.77,
+                                "end": 35.17,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "various"
+                            },
+                            {
+                                "word": "news",
+                                "start": 35.17,
+                                "end": 35.41,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "news"
+                            },
+                            {
+                                "word": "outlets",
+                                "start": 35.41,
+                                "end": 35.89,
+                                "confidence": 0.8796387,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "outlets,"
+                            },
+                            {
+                                "word": "including",
+                                "start": 35.89,
+                                "end": 36.39,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "including"
+                            },
+                            {
+                                "word": "cnn",
+                                "start": 36.45,
+                                "end": 36.95,
+                                "confidence": 0.9929199,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "CNN."
+                            },
+                            {
+                                "word": "however",
+                                "start": 37.01,
+                                "end": 37.41,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "However,"
+                            },
+                            {
+                                "word": "despite",
+                                "start": 37.41,
+                                "end": 37.809998,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "despite"
+                            },
+                            {
+                                "word": "cnn's",
+                                "start": 37.809998,
+                                "end": 38.29,
+                                "confidence": 0.9812012,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "CNN's"
+                            },
+                            {
+                                "word": "rejection",
+                                "start": 38.29,
+                                "end": 38.79,
+                                "confidence": 0.9946289,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "rejection,"
+                            },
+                            {
+                                "word": "the",
+                                "start": 38.85,
+                                "end": 39.01,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "president",
+                                "start": 39.01,
+                                "end": 39.329998,
+                                "confidence": 0.97998047,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "president"
+                            },
+                            {
+                                "word": "posted",
+                                "start": 39.329998,
+                                "end": 39.73,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "posted"
+                            },
+                            {
+                                "word": "the",
+                                "start": 39.73,
+                                "end": 39.89,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "advertisement",
+                                "start": 39.89,
+                                "end": 40.39,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "advertisement"
+                            },
+                            {
+                                "word": "onto",
+                                "start": 40.449997,
+                                "end": 40.69,
+                                "confidence": 0.9584961,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "onto"
+                            },
+                            {
+                                "word": "his",
+                                "start": 40.69,
+                                "end": 40.85,
+                                "confidence": 0.9970703,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "his"
+                            },
+                            {
+                                "word": "twitter",
+                                "start": 40.85,
+                                "end": 41.345,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "Twitter"
+                            },
+                            {
+                                "word": "each",
+                                "start": 41.345,
+                                "end": 41.585003,
+                                "confidence": 0.37158203,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "each"
+                            },
+                            {
+                                "word": "last",
+                                "start": 41.585003,
+                                "end": 41.905003,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "last"
+                            },
+                            {
+                                "word": "week",
+                                "start": 41.905003,
+                                "end": 42.225002,
+                                "confidence": 0.7651367,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "week,"
+                            },
+                            {
+                                "word": "along",
+                                "start": 42.225002,
+                                "end": 42.545002,
+                                "confidence": 0.99609375,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "along"
+                            },
+                            {
+                                "word": "with",
+                                "start": 42.545002,
+                                "end": 42.705,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "with"
+                            },
+                            {
+                                "word": "the",
+                                "start": 42.705,
+                                "end": 42.865,
+                                "confidence": 0.9863281,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "caption",
+                                "start": 42.865,
+                                "end": 43.345,
+                                "confidence": 0.93188477,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "caption,"
+                            },
+                            {
+                                "word": "i'm",
+                                "start": 43.345,
+                                "end": 43.585003,
+                                "confidence": 0.86938477,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "I'm"
+                            },
+                            {
+                                "word": "draining",
+                                "start": 43.585003,
+                                "end": 44.065002,
+                                "confidence": 0.9946289,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "draining"
+                            },
+                            {
+                                "word": "the",
+                                "start": 44.065002,
+                                "end": 44.145,
+                                "confidence": 0.9926758,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "swamp",
+                                "start": 44.145,
+                                "end": 44.645,
+                                "confidence": 0.9716797,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8604965,
+                                "punctuated_word": "swamp."
+                            },
+                            {
+                                "word": "now",
+                                "start": 44.705,
+                                "end": 44.865,
+                                "confidence": 0.782959,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "Now,"
+                            },
+                            {
+                                "word": "this",
+                                "start": 44.865,
+                                "end": 45.105,
+                                "confidence": 0.9970703,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "this"
+                            },
+                            {
+                                "word": "is",
+                                "start": 45.105,
+                                "end": 45.265,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "is"
+                            },
+                            {
+                                "word": "not",
+                                "start": 45.265,
+                                "end": 45.505,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "not"
+                            },
+                            {
+                                "word": "the",
+                                "start": 45.505,
+                                "end": 45.665,
+                                "confidence": 0.99658203,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "first",
+                                "start": 45.665,
+                                "end": 45.825,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "first"
+                            },
+                            {
+                                "word": "time",
+                                "start": 45.825,
+                                "end": 46.065002,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "time"
+                            },
+                            {
+                                "word": "cnn",
+                                "start": 46.065002,
+                                "end": 46.465,
+                                "confidence": 0.9628906,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "CNN"
+                            },
+                            {
+                                "word": "has",
+                                "start": 46.465,
+                                "end": 46.705,
+                                "confidence": 0.99853516,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "has"
+                            },
+                            {
+                                "word": "rejected",
+                                "start": 46.705,
+                                "end": 47.185,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "rejected"
+                            },
+                            {
+                                "word": "a",
+                                "start": 47.185,
+                                "end": 47.345,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "a"
+                            },
+                            {
+                                "word": "trump",
+                                "start": 47.345,
+                                "end": 47.585,
+                                "confidence": 0.85595703,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "Trump"
+                            },
+                            {
+                                "word": "campaign",
+                                "start": 47.585,
+                                "end": 48.085,
+                                "confidence": 0.9824219,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "campaign"
+                            },
+                            {
+                                "word": "ad",
+                                "start": 48.145,
+                                "end": 48.545002,
+                                "confidence": 0.751709,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "ad."
+                            },
+                            {
+                                "word": "back",
+                                "start": 48.545002,
+                                "end": 48.705,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "Back"
+                            },
+                            {
+                                "word": "in",
+                                "start": 48.705,
+                                "end": 48.865,
+                                "confidence": 0.9951172,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "in"
+                            },
+                            {
+                                "word": "twenty",
+                                "start": 48.865,
+                                "end": 49.185,
+                                "confidence": 0.99316406,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "twenty"
+                            },
+                            {
+                                "word": "seventeen",
+                                "start": 49.185,
+                                "end": 49.665,
+                                "confidence": 0.98413086,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "seventeen,"
+                            },
+                            {
+                                "word": "the",
+                                "start": 49.665,
+                                "end": 49.95,
+                                "confidence": 0.86279297,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "refused",
+                                "start": 49.95,
+                                "end": 50.45,
+                                "confidence": 0.76538086,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "refused"
+                            },
+                            {
+                                "word": "to",
+                                "start": 50.510002,
+                                "end": 50.59,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "to"
+                            },
+                            {
+                                "word": "run",
+                                "start": 50.59,
+                                "end": 50.83,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "run"
+                            },
+                            {
+                                "word": "a",
+                                "start": 50.83,
+                                "end": 50.99,
+                                "confidence": 0.99853516,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "a"
+                            },
+                            {
+                                "word": "trump",
+                                "start": 50.99,
+                                "end": 51.23,
+                                "confidence": 0.88427734,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "Trump"
+                            },
+                            {
+                                "word": "approved",
+                                "start": 51.23,
+                                "end": 51.63,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "approved"
+                            },
+                            {
+                                "word": "ad",
+                                "start": 51.63,
+                                "end": 52.03,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "ad"
+                            },
+                            {
+                                "word": "called",
+                                "start": 52.03,
+                                "end": 52.43,
+                                "confidence": 0.9692383,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "called"
+                            },
+                            {
+                                "word": "let",
+                                "start": 52.43,
+                                "end": 52.670002,
+                                "confidence": 0.53271484,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "let"
+                            },
+                            {
+                                "word": "president",
+                                "start": 52.670002,
+                                "end": 53.15,
+                                "confidence": 0.54589844,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "president"
+                            },
+                            {
+                                "word": "trump",
+                                "start": 53.15,
+                                "end": 53.47,
+                                "confidence": 0.8515625,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "Trump"
+                            },
+                            {
+                                "word": "do",
+                                "start": 53.47,
+                                "end": 53.63,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "do"
+                            },
+                            {
+                                "word": "his",
+                                "start": 53.63,
+                                "end": 53.95,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "his"
+                            },
+                            {
+                                "word": "job",
+                                "start": 53.95,
+                                "end": 54.27,
+                                "confidence": 0.9038086,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "job,"
+                            },
+                            {
+                                "word": "which",
+                                "start": 54.27,
+                                "end": 54.510002,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "which"
+                            },
+                            {
+                                "word": "criticized",
+                                "start": 54.510002,
+                                "end": 55.010002,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.8530749,
+                                "punctuated_word": "criticized"
+                            },
+                            {
+                                "word": "the",
+                                "start": 55.07,
+                                "end": 55.15,
+                                "confidence": 0.99853516,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "media",
+                                "start": 55.15,
+                                "end": 55.55,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "media"
+                            },
+                            {
+                                "word": "and",
+                                "start": 55.55,
+                                "end": 55.79,
+                                "confidence": 0.78222656,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "and"
+                            },
+                            {
+                                "word": "specifically",
+                                "start": 55.79,
+                                "end": 56.29,
+                                "confidence": 0.99853516,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "specifically"
+                            },
+                            {
+                                "word": "called",
+                                "start": 56.510002,
+                                "end": 56.75,
+                                "confidence": 0.99560547,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "called"
+                            },
+                            {
+                                "word": "out",
+                                "start": 56.75,
+                                "end": 56.91,
+                                "confidence": 0.99658203,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "out"
+                            },
+                            {
+                                "word": "lemon",
+                                "start": 56.91,
+                                "end": 57.23,
+                                "confidence": 0.68115234,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "lemon"
+                            },
+                            {
+                                "word": "as",
+                                "start": 57.23,
+                                "end": 57.39,
+                                "confidence": 0.6142578,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "as"
+                            },
+                            {
+                                "word": "well",
+                                "start": 57.39,
+                                "end": 57.55,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "well"
+                            },
+                            {
+                                "word": "as",
+                                "start": 57.55,
+                                "end": 57.79,
+                                "confidence": 0.99853516,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "as"
+                            },
+                            {
+                                "word": "anderson",
+                                "start": 57.79,
+                                "end": 58.11,
+                                "confidence": 0.8964844,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "Anderson"
+                            },
+                            {
+                                "word": "cooper",
+                                "start": 58.11,
+                                "end": 58.585,
+                                "confidence": 0.7988281,
+                                "speaker": 0,
+                                "speaker_confidence": 0.60973746,
+                                "punctuated_word": "Cooper."
+                            },
+                            {
+                                "word": "to",
+                                "start": 58.905,
+                                "end": 59.065,
+                                "confidence": 0.47143555,
+                                "speaker": 0,
+                                "speaker_confidence": 0.30368042,
+                                "punctuated_word": "To"
+                            },
+                            {
+                                "word": "stay",
+                                "start": 59.065,
+                                "end": 59.225,
+                                "confidence": 0.9975586,
+                                "speaker": 0,
+                                "speaker_confidence": 0.30368042,
+                                "punctuated_word": "stay"
+                            },
+                            {
+                                "word": "up",
+                                "start": 59.225,
+                                "end": 59.385,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.30368042,
+                                "punctuated_word": "up"
+                            },
+                            {
+                                "word": "to",
+                                "start": 59.385,
+                                "end": 59.545,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.30368042,
+                                "punctuated_word": "to"
+                            },
+                            {
+                                "word": "date",
+                                "start": 59.545,
+                                "end": 59.704998,
+                                "confidence": 1.0,
+                                "speaker": 0,
+                                "speaker_confidence": 0.30368042,
+                                "punctuated_word": "date"
+                            },
+                            {
+                                "word": "on",
+                                "start": 59.704998,
+                                "end": 59.864998,
+                                "confidence": 0.9970703,
+                                "speaker": 0,
+                                "speaker_confidence": 0.30368042,
+                                "punctuated_word": "on"
+                            },
+                            {
+                                "word": "this",
+                                "start": 59.864998,
+                                "end": 59.945,
+                                "confidence": 0.56152344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "this"
+                            },
+                            {
+                                "word": "story",
+                                "start": 59.945,
+                                "end": 60.265,
+                                "confidence": 0.94433594,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "story,"
+                            },
+                            {
+                                "word": "hit",
+                                "start": 60.265,
+                                "end": 60.504997,
+                                "confidence": 0.9506836,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "hit"
+                            },
+                            {
+                                "word": "the",
+                                "start": 60.504997,
+                                "end": 60.665,
+                                "confidence": 0.4946289,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "thr",
+                                "start": 60.665,
+                                "end": 61.065,
+                                "confidence": 0.9326172,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "thr"
+                            },
+                            {
+                                "word": "dot",
+                                "start": 61.065,
+                                "end": 61.305,
+                                "confidence": 0.984375,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "dot"
+                            },
+                            {
+                                "word": "com",
+                                "start": 61.305,
+                                "end": 61.545,
+                                "confidence": 0.71813965,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "com,"
+                            },
+                            {
+                                "word": "and",
+                                "start": 61.545,
+                                "end": 61.785,
+                                "confidence": 0.99902344,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "and"
+                            },
+                            {
+                                "word": "until",
+                                "start": 61.785,
+                                "end": 62.105,
+                                "confidence": 0.9980469,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "until"
+                            },
+                            {
+                                "word": "next",
+                                "start": 62.105,
+                                "end": 62.265,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "next"
+                            },
+                            {
+                                "word": "time",
+                                "start": 62.265,
+                                "end": 62.425,
+                                "confidence": 0.9995117,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "time"
+                            },
+                            {
+                                "word": "for",
+                                "start": 62.425,
+                                "end": 62.585,
+                                "confidence": 0.9550781,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "for"
+                            },
+                            {
+                                "word": "the",
+                                "start": 62.585,
+                                "end": 62.665,
+                                "confidence": 0.96484375,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "the"
+                            },
+                            {
+                                "word": "hollywood",
+                                "start": 62.665,
+                                "end": 63.065,
+                                "confidence": 0.9711914,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "Hollywood"
+                            },
+                            {
+                                "word": "reporter",
+                                "start": 63.065,
+                                "end": 63.385,
+                                "confidence": 0.9604492,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "reporter"
+                            },
+                            {
+                                "word": "news",
+                                "start": 63.385,
+                                "end": 63.704998,
+                                "confidence": 0.76586914,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "news,"
+                            },
+                            {
+                                "word": "i",
+                                "start": 63.704998,
+                                "end": 63.785,
+                                "confidence": 0.72021484,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "I"
+                            },
+                            {
+                                "word": "may",
+                                "start": 63.785,
+                                "end": 63.945,
+                                "confidence": 0.86083984,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "may"
+                            },
+                            {
+                                "word": "enjoy",
+                                "start": 63.945,
+                                "end": 64.445,
+                                "confidence": 0.75561523,
+                                "speaker": 0,
+                                "speaker_confidence": 0.57561845,
+                                "punctuated_word": "enjoy."
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "utterances": [
+            {
+                "start": 0.24,
+                "end": 6.8199997,
+                "confidence": 0.97686213,
+                "channel": 0,
+                "transcript": "CNN has decided not to run a Donald Trump endorsed campaign ad after the network decided it does not meet their standards.",
+                "words": [
+                    {
+                        "word": "cnn",
+                        "start": 0.24,
+                        "end": 0.71999997,
+                        "confidence": 0.73828125,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "CNN"
+                    },
+                    {
+                        "word": "has",
+                        "start": 0.71999997,
+                        "end": 0.88,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "has"
+                    },
+                    {
+                        "word": "decided",
+                        "start": 0.88,
+                        "end": 1.38,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "decided"
+                    },
+                    {
+                        "word": "not",
+                        "start": 1.4399999,
+                        "end": 1.68,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "not"
+                    },
+                    {
+                        "word": "to",
+                        "start": 1.68,
+                        "end": 1.8399999,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "to"
+                    },
+                    {
+                        "word": "run",
+                        "start": 1.8399999,
+                        "end": 2.08,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "run"
+                    },
+                    {
+                        "word": "a",
+                        "start": 2.08,
+                        "end": 2.1599998,
+                        "confidence": 0.95654297,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "a"
+                    },
+                    {
+                        "word": "donald",
+                        "start": 2.1599998,
+                        "end": 2.48,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "Donald"
+                    },
+                    {
+                        "word": "trump",
+                        "start": 2.48,
+                        "end": 2.72,
+                        "confidence": 0.99609375,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "Trump"
+                    },
+                    {
+                        "word": "endorsed",
+                        "start": 2.72,
+                        "end": 3.12,
+                        "confidence": 0.99316406,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "endorsed"
+                    },
+                    {
+                        "word": "campaign",
+                        "start": 3.12,
+                        "end": 3.62,
+                        "confidence": 0.9135742,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "campaign"
+                    },
+                    {
+                        "word": "ad",
+                        "start": 3.6799998,
+                        "end": 3.9199998,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "ad"
+                    },
+                    {
+                        "word": "after",
+                        "start": 3.9199998,
+                        "end": 4.24,
+                        "confidence": 0.9296875,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "after"
+                    },
+                    {
+                        "word": "the",
+                        "start": 4.24,
+                        "end": 4.4,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "network",
+                        "start": 4.4,
+                        "end": 4.7999997,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "network"
+                    },
+                    {
+                        "word": "decided",
+                        "start": 4.7999997,
+                        "end": 5.2799997,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "decided"
+                    },
+                    {
+                        "word": "it",
+                        "start": 5.2799997,
+                        "end": 5.52,
+                        "confidence": 0.9863281,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "it"
+                    },
+                    {
+                        "word": "does",
+                        "start": 5.52,
+                        "end": 5.68,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "does"
+                    },
+                    {
+                        "word": "not",
+                        "start": 5.68,
+                        "end": 5.92,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "not"
+                    },
+                    {
+                        "word": "meet",
+                        "start": 5.92,
+                        "end": 6.08,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "meet"
+                    },
+                    {
+                        "word": "their",
+                        "start": 6.08,
+                        "end": 6.3199997,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "their"
+                    },
+                    {
+                        "word": "standards",
+                        "start": 6.3199997,
+                        "end": 6.8199997,
+                        "confidence": 0.99194336,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8238818,
+                        "punctuated_word": "standards."
+                    }
+                ],
+                "speaker": 0,
+                "id": "925c2d2b-94e2-44d0-a972-e5e684f84f35"
+            },
+            {
+                "start": 8.565,
+                "end": 22.289999,
+                "confidence": 0.94977087,
+                "channel": 0,
+                "transcript": "The thirty second advertisement paid for by Trump's campaign targeted Joe Biden's conduct toward Ukraine while he served as vice president. While also referring to CNN personalities, Don Lemmon, Chris Cuomo, and Jim Acosta, as media lapdogs.",
+                "words": [
+                    {
+                        "word": "the",
+                        "start": 8.565,
+                        "end": 8.724999,
+                        "confidence": 0.98291016,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "The"
+                    },
+                    {
+                        "word": "thirty",
+                        "start": 8.724999,
+                        "end": 9.045,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "thirty"
+                    },
+                    {
+                        "word": "second",
+                        "start": 9.045,
+                        "end": 9.445,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "second"
+                    },
+                    {
+                        "word": "advertisement",
+                        "start": 9.445,
+                        "end": 9.945,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "advertisement"
+                    },
+                    {
+                        "word": "paid",
+                        "start": 10.085,
+                        "end": 10.325,
+                        "confidence": 0.9248047,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "paid"
+                    },
+                    {
+                        "word": "for",
+                        "start": 10.325,
+                        "end": 10.565,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "for"
+                    },
+                    {
+                        "word": "by",
+                        "start": 10.565,
+                        "end": 10.725,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "by"
+                    },
+                    {
+                        "word": "trump's",
+                        "start": 10.725,
+                        "end": 11.125,
+                        "confidence": 0.98657227,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Trump's"
+                    },
+                    {
+                        "word": "campaign",
+                        "start": 11.125,
+                        "end": 11.625,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "campaign"
+                    },
+                    {
+                        "word": "targeted",
+                        "start": 11.764999,
+                        "end": 12.245,
+                        "confidence": 0.68896484,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "targeted"
+                    },
+                    {
+                        "word": "joe",
+                        "start": 12.245,
+                        "end": 12.485,
+                        "confidence": 0.9921875,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Joe"
+                    },
+                    {
+                        "word": "biden's",
+                        "start": 12.485,
+                        "end": 12.965,
+                        "confidence": 0.998291,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Biden's"
+                    },
+                    {
+                        "word": "conduct",
+                        "start": 12.965,
+                        "end": 13.365,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "conduct"
+                    },
+                    {
+                        "word": "toward",
+                        "start": 13.365,
+                        "end": 13.684999,
+                        "confidence": 0.9658203,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "toward"
+                    },
+                    {
+                        "word": "ukraine",
+                        "start": 13.684999,
+                        "end": 14.184999,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Ukraine"
+                    },
+                    {
+                        "word": "while",
+                        "start": 14.245,
+                        "end": 14.485,
+                        "confidence": 0.8154297,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "while"
+                    },
+                    {
+                        "word": "he",
+                        "start": 14.485,
+                        "end": 14.6449995,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "he"
+                    },
+                    {
+                        "word": "served",
+                        "start": 14.6449995,
+                        "end": 14.965,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "served"
+                    },
+                    {
+                        "word": "as",
+                        "start": 14.965,
+                        "end": 15.125,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "as"
+                    },
+                    {
+                        "word": "vice",
+                        "start": 15.125,
+                        "end": 15.445,
+                        "confidence": 0.9873047,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "vice"
+                    },
+                    {
+                        "word": "president",
+                        "start": 15.445,
+                        "end": 15.945,
+                        "confidence": 0.8586426,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "president."
+                    },
+                    {
+                        "word": "while",
+                        "start": 16.03,
+                        "end": 16.27,
+                        "confidence": 0.9868164,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "While"
+                    },
+                    {
+                        "word": "also",
+                        "start": 16.27,
+                        "end": 16.59,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "also"
+                    },
+                    {
+                        "word": "referring",
+                        "start": 16.59,
+                        "end": 16.99,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "referring"
+                    },
+                    {
+                        "word": "to",
+                        "start": 16.99,
+                        "end": 17.15,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "to"
+                    },
+                    {
+                        "word": "cnn",
+                        "start": 17.15,
+                        "end": 17.63,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "CNN"
+                    },
+                    {
+                        "word": "personalities",
+                        "start": 17.63,
+                        "end": 18.13,
+                        "confidence": 0.9086914,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "personalities,"
+                    },
+                    {
+                        "word": "don",
+                        "start": 18.35,
+                        "end": 18.59,
+                        "confidence": 0.9140625,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Don"
+                    },
+                    {
+                        "word": "lemmon",
+                        "start": 18.59,
+                        "end": 19.09,
+                        "confidence": 0.7232259,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Lemmon,"
+                    },
+                    {
+                        "word": "chris",
+                        "start": 19.23,
+                        "end": 19.47,
+                        "confidence": 0.98291016,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Chris"
+                    },
+                    {
+                        "word": "cuomo",
+                        "start": 19.47,
+                        "end": 19.97,
+                        "confidence": 0.89868164,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Cuomo,"
+                    },
+                    {
+                        "word": "and",
+                        "start": 20.189999,
+                        "end": 20.43,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "and"
+                    },
+                    {
+                        "word": "jim",
+                        "start": 20.43,
+                        "end": 20.67,
+                        "confidence": 0.9370117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Jim"
+                    },
+                    {
+                        "word": "acosta",
+                        "start": 20.67,
+                        "end": 21.17,
+                        "confidence": 0.8022461,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "Acosta,"
+                    },
+                    {
+                        "word": "as",
+                        "start": 21.23,
+                        "end": 21.39,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "as"
+                    },
+                    {
+                        "word": "media",
+                        "start": 21.39,
+                        "end": 21.789999,
+                        "confidence": 0.98291016,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "media"
+                    },
+                    {
+                        "word": "lapdogs",
+                        "start": 21.789999,
+                        "end": 22.289999,
+                        "confidence": 0.82161456,
+                        "speaker": 0,
+                        "speaker_confidence": 0.9041902,
+                        "punctuated_word": "lapdogs."
+                    }
+                ],
+                "speaker": 0,
+                "id": "02f80975-c7ea-4b59-986a-0b29a37ba792"
+            },
+            {
+                "start": 22.75,
+                "end": 64.445,
+                "confidence": 0.93077713,
+                "channel": 0,
+                "transcript": "A CNN spokesperson spoke to THR saying the ad does not meet the network's advertising standards adding. In addition to disparaging CNN and its journalists, the ad makes assertions that have been proven demonstrably false by various news outlets, including CNN. However, despite CNN's rejection, the president posted the advertisement onto his Twitter each last week, along with the caption, I'm draining the swamp. Now, this is not the first time CNN has rejected a Trump campaign ad. Back in twenty seventeen, the refused to run a Trump approved ad called let president Trump do his job, which criticized the media and specifically called out lemon as well as Anderson Cooper. To stay up to date on this story, hit the thr dot com, and until next time for the Hollywood reporter news, I may enjoy.",
+                "words": [
+                    {
+                        "word": "a",
+                        "start": 22.75,
+                        "end": 22.91,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "A"
+                    },
+                    {
+                        "word": "cnn",
+                        "start": 22.91,
+                        "end": 23.41,
+                        "confidence": 0.9941406,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "CNN"
+                    },
+                    {
+                        "word": "spokesperson",
+                        "start": 23.47,
+                        "end": 23.97,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "spokesperson"
+                    },
+                    {
+                        "word": "spoke",
+                        "start": 24.029999,
+                        "end": 24.349998,
+                        "confidence": 0.9946289,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "spoke"
+                    },
+                    {
+                        "word": "to",
+                        "start": 24.349998,
+                        "end": 24.465,
+                        "confidence": 0.89941406,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "to"
+                    },
+                    {
+                        "word": "thr",
+                        "start": 24.465,
+                        "end": 24.965,
+                        "confidence": 0.6654053,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "THR"
+                    },
+                    {
+                        "word": "saying",
+                        "start": 25.025,
+                        "end": 25.265,
+                        "confidence": 0.5761719,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "saying"
+                    },
+                    {
+                        "word": "the",
+                        "start": 25.265,
+                        "end": 25.425,
+                        "confidence": 0.9824219,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "ad",
+                        "start": 25.425,
+                        "end": 25.745,
+                        "confidence": 0.9916992,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "ad"
+                    },
+                    {
+                        "word": "does",
+                        "start": 25.745,
+                        "end": 25.905,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "does"
+                    },
+                    {
+                        "word": "not",
+                        "start": 25.905,
+                        "end": 26.145,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "not"
+                    },
+                    {
+                        "word": "meet",
+                        "start": 26.145,
+                        "end": 26.385,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "meet"
+                    },
+                    {
+                        "word": "the",
+                        "start": 26.385,
+                        "end": 26.545,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "network's",
+                        "start": 26.545,
+                        "end": 26.945,
+                        "confidence": 0.97802734,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "network's"
+                    },
+                    {
+                        "word": "advertising",
+                        "start": 26.945,
+                        "end": 27.445,
+                        "confidence": 0.9868164,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "advertising"
+                    },
+                    {
+                        "word": "standards",
+                        "start": 27.585,
+                        "end": 28.065,
+                        "confidence": 0.9951172,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "standards"
+                    },
+                    {
+                        "word": "adding",
+                        "start": 28.065,
+                        "end": 28.565,
+                        "confidence": 0.7368164,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "adding."
+                    },
+                    {
+                        "word": "in",
+                        "start": 28.705,
+                        "end": 28.945,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "In"
+                    },
+                    {
+                        "word": "addition",
+                        "start": 28.945,
+                        "end": 29.265,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "addition"
+                    },
+                    {
+                        "word": "to",
+                        "start": 29.265,
+                        "end": 29.425,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "to"
+                    },
+                    {
+                        "word": "disparaging",
+                        "start": 29.425,
+                        "end": 29.925,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "disparaging"
+                    },
+                    {
+                        "word": "cnn",
+                        "start": 29.985,
+                        "end": 30.465,
+                        "confidence": 0.96484375,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "CNN"
+                    },
+                    {
+                        "word": "and",
+                        "start": 30.465,
+                        "end": 30.705,
+                        "confidence": 0.9863281,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "and"
+                    },
+                    {
+                        "word": "its",
+                        "start": 30.705,
+                        "end": 30.945,
+                        "confidence": 0.9921875,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "its"
+                    },
+                    {
+                        "word": "journalists",
+                        "start": 30.945,
+                        "end": 31.445,
+                        "confidence": 0.96875,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "journalists,"
+                    },
+                    {
+                        "word": "the",
+                        "start": 31.505001,
+                        "end": 31.665,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "ad",
+                        "start": 31.665,
+                        "end": 31.825,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "ad"
+                    },
+                    {
+                        "word": "makes",
+                        "start": 31.825,
+                        "end": 32.145,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "makes"
+                    },
+                    {
+                        "word": "assertions",
+                        "start": 32.145,
+                        "end": 32.625,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "assertions"
+                    },
+                    {
+                        "word": "that",
+                        "start": 32.625,
+                        "end": 32.785,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.86213976,
+                        "punctuated_word": "that"
+                    },
+                    {
+                        "word": "have",
+                        "start": 32.785,
+                        "end": 32.864998,
+                        "confidence": 0.9970703,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "have"
+                    },
+                    {
+                        "word": "been",
+                        "start": 32.864998,
+                        "end": 33.025,
+                        "confidence": 0.99609375,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "been"
+                    },
+                    {
+                        "word": "proven",
+                        "start": 33.025,
+                        "end": 33.505,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "proven"
+                    },
+                    {
+                        "word": "demonstrably",
+                        "start": 33.505,
+                        "end": 34.005,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "demonstrably"
+                    },
+                    {
+                        "word": "false",
+                        "start": 34.21,
+                        "end": 34.53,
+                        "confidence": 0.9082031,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "false"
+                    },
+                    {
+                        "word": "by",
+                        "start": 34.53,
+                        "end": 34.77,
+                        "confidence": 0.98828125,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "by"
+                    },
+                    {
+                        "word": "various",
+                        "start": 34.77,
+                        "end": 35.17,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "various"
+                    },
+                    {
+                        "word": "news",
+                        "start": 35.17,
+                        "end": 35.41,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "news"
+                    },
+                    {
+                        "word": "outlets",
+                        "start": 35.41,
+                        "end": 35.89,
+                        "confidence": 0.8796387,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "outlets,"
+                    },
+                    {
+                        "word": "including",
+                        "start": 35.89,
+                        "end": 36.39,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "including"
+                    },
+                    {
+                        "word": "cnn",
+                        "start": 36.45,
+                        "end": 36.95,
+                        "confidence": 0.9929199,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "CNN."
+                    },
+                    {
+                        "word": "however",
+                        "start": 37.01,
+                        "end": 37.41,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "However,"
+                    },
+                    {
+                        "word": "despite",
+                        "start": 37.41,
+                        "end": 37.809998,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "despite"
+                    },
+                    {
+                        "word": "cnn's",
+                        "start": 37.809998,
+                        "end": 38.29,
+                        "confidence": 0.9812012,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "CNN's"
+                    },
+                    {
+                        "word": "rejection",
+                        "start": 38.29,
+                        "end": 38.79,
+                        "confidence": 0.9946289,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "rejection,"
+                    },
+                    {
+                        "word": "the",
+                        "start": 38.85,
+                        "end": 39.01,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "president",
+                        "start": 39.01,
+                        "end": 39.329998,
+                        "confidence": 0.97998047,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "president"
+                    },
+                    {
+                        "word": "posted",
+                        "start": 39.329998,
+                        "end": 39.73,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "posted"
+                    },
+                    {
+                        "word": "the",
+                        "start": 39.73,
+                        "end": 39.89,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "advertisement",
+                        "start": 39.89,
+                        "end": 40.39,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "advertisement"
+                    },
+                    {
+                        "word": "onto",
+                        "start": 40.449997,
+                        "end": 40.69,
+                        "confidence": 0.9584961,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "onto"
+                    },
+                    {
+                        "word": "his",
+                        "start": 40.69,
+                        "end": 40.85,
+                        "confidence": 0.9970703,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "his"
+                    },
+                    {
+                        "word": "twitter",
+                        "start": 40.85,
+                        "end": 41.345,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "Twitter"
+                    },
+                    {
+                        "word": "each",
+                        "start": 41.345,
+                        "end": 41.585003,
+                        "confidence": 0.37158203,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "each"
+                    },
+                    {
+                        "word": "last",
+                        "start": 41.585003,
+                        "end": 41.905003,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "last"
+                    },
+                    {
+                        "word": "week",
+                        "start": 41.905003,
+                        "end": 42.225002,
+                        "confidence": 0.7651367,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "week,"
+                    },
+                    {
+                        "word": "along",
+                        "start": 42.225002,
+                        "end": 42.545002,
+                        "confidence": 0.99609375,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "along"
+                    },
+                    {
+                        "word": "with",
+                        "start": 42.545002,
+                        "end": 42.705,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "with"
+                    },
+                    {
+                        "word": "the",
+                        "start": 42.705,
+                        "end": 42.865,
+                        "confidence": 0.9863281,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "caption",
+                        "start": 42.865,
+                        "end": 43.345,
+                        "confidence": 0.93188477,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "caption,"
+                    },
+                    {
+                        "word": "i'm",
+                        "start": 43.345,
+                        "end": 43.585003,
+                        "confidence": 0.86938477,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "I'm"
+                    },
+                    {
+                        "word": "draining",
+                        "start": 43.585003,
+                        "end": 44.065002,
+                        "confidence": 0.9946289,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "draining"
+                    },
+                    {
+                        "word": "the",
+                        "start": 44.065002,
+                        "end": 44.145,
+                        "confidence": 0.9926758,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "swamp",
+                        "start": 44.145,
+                        "end": 44.645,
+                        "confidence": 0.9716797,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8604965,
+                        "punctuated_word": "swamp."
+                    },
+                    {
+                        "word": "now",
+                        "start": 44.705,
+                        "end": 44.865,
+                        "confidence": 0.782959,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "Now,"
+                    },
+                    {
+                        "word": "this",
+                        "start": 44.865,
+                        "end": 45.105,
+                        "confidence": 0.9970703,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "this"
+                    },
+                    {
+                        "word": "is",
+                        "start": 45.105,
+                        "end": 45.265,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "is"
+                    },
+                    {
+                        "word": "not",
+                        "start": 45.265,
+                        "end": 45.505,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "not"
+                    },
+                    {
+                        "word": "the",
+                        "start": 45.505,
+                        "end": 45.665,
+                        "confidence": 0.99658203,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "first",
+                        "start": 45.665,
+                        "end": 45.825,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "first"
+                    },
+                    {
+                        "word": "time",
+                        "start": 45.825,
+                        "end": 46.065002,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "time"
+                    },
+                    {
+                        "word": "cnn",
+                        "start": 46.065002,
+                        "end": 46.465,
+                        "confidence": 0.9628906,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "CNN"
+                    },
+                    {
+                        "word": "has",
+                        "start": 46.465,
+                        "end": 46.705,
+                        "confidence": 0.99853516,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "has"
+                    },
+                    {
+                        "word": "rejected",
+                        "start": 46.705,
+                        "end": 47.185,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "rejected"
+                    },
+                    {
+                        "word": "a",
+                        "start": 47.185,
+                        "end": 47.345,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "a"
+                    },
+                    {
+                        "word": "trump",
+                        "start": 47.345,
+                        "end": 47.585,
+                        "confidence": 0.85595703,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "Trump"
+                    },
+                    {
+                        "word": "campaign",
+                        "start": 47.585,
+                        "end": 48.085,
+                        "confidence": 0.9824219,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "campaign"
+                    },
+                    {
+                        "word": "ad",
+                        "start": 48.145,
+                        "end": 48.545002,
+                        "confidence": 0.751709,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "ad."
+                    },
+                    {
+                        "word": "back",
+                        "start": 48.545002,
+                        "end": 48.705,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "Back"
+                    },
+                    {
+                        "word": "in",
+                        "start": 48.705,
+                        "end": 48.865,
+                        "confidence": 0.9951172,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "in"
+                    },
+                    {
+                        "word": "twenty",
+                        "start": 48.865,
+                        "end": 49.185,
+                        "confidence": 0.99316406,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "twenty"
+                    },
+                    {
+                        "word": "seventeen",
+                        "start": 49.185,
+                        "end": 49.665,
+                        "confidence": 0.98413086,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "seventeen,"
+                    },
+                    {
+                        "word": "the",
+                        "start": 49.665,
+                        "end": 49.95,
+                        "confidence": 0.86279297,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "refused",
+                        "start": 49.95,
+                        "end": 50.45,
+                        "confidence": 0.76538086,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "refused"
+                    },
+                    {
+                        "word": "to",
+                        "start": 50.510002,
+                        "end": 50.59,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "to"
+                    },
+                    {
+                        "word": "run",
+                        "start": 50.59,
+                        "end": 50.83,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "run"
+                    },
+                    {
+                        "word": "a",
+                        "start": 50.83,
+                        "end": 50.99,
+                        "confidence": 0.99853516,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "a"
+                    },
+                    {
+                        "word": "trump",
+                        "start": 50.99,
+                        "end": 51.23,
+                        "confidence": 0.88427734,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "Trump"
+                    },
+                    {
+                        "word": "approved",
+                        "start": 51.23,
+                        "end": 51.63,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "approved"
+                    },
+                    {
+                        "word": "ad",
+                        "start": 51.63,
+                        "end": 52.03,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "ad"
+                    },
+                    {
+                        "word": "called",
+                        "start": 52.03,
+                        "end": 52.43,
+                        "confidence": 0.9692383,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "called"
+                    },
+                    {
+                        "word": "let",
+                        "start": 52.43,
+                        "end": 52.670002,
+                        "confidence": 0.53271484,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "let"
+                    },
+                    {
+                        "word": "president",
+                        "start": 52.670002,
+                        "end": 53.15,
+                        "confidence": 0.54589844,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "president"
+                    },
+                    {
+                        "word": "trump",
+                        "start": 53.15,
+                        "end": 53.47,
+                        "confidence": 0.8515625,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "Trump"
+                    },
+                    {
+                        "word": "do",
+                        "start": 53.47,
+                        "end": 53.63,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "do"
+                    },
+                    {
+                        "word": "his",
+                        "start": 53.63,
+                        "end": 53.95,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "his"
+                    },
+                    {
+                        "word": "job",
+                        "start": 53.95,
+                        "end": 54.27,
+                        "confidence": 0.9038086,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "job,"
+                    },
+                    {
+                        "word": "which",
+                        "start": 54.27,
+                        "end": 54.510002,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "which"
+                    },
+                    {
+                        "word": "criticized",
+                        "start": 54.510002,
+                        "end": 55.010002,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.8530749,
+                        "punctuated_word": "criticized"
+                    },
+                    {
+                        "word": "the",
+                        "start": 55.07,
+                        "end": 55.15,
+                        "confidence": 0.99853516,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "media",
+                        "start": 55.15,
+                        "end": 55.55,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "media"
+                    },
+                    {
+                        "word": "and",
+                        "start": 55.55,
+                        "end": 55.79,
+                        "confidence": 0.78222656,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "and"
+                    },
+                    {
+                        "word": "specifically",
+                        "start": 55.79,
+                        "end": 56.29,
+                        "confidence": 0.99853516,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "specifically"
+                    },
+                    {
+                        "word": "called",
+                        "start": 56.510002,
+                        "end": 56.75,
+                        "confidence": 0.99560547,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "called"
+                    },
+                    {
+                        "word": "out",
+                        "start": 56.75,
+                        "end": 56.91,
+                        "confidence": 0.99658203,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "out"
+                    },
+                    {
+                        "word": "lemon",
+                        "start": 56.91,
+                        "end": 57.23,
+                        "confidence": 0.68115234,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "lemon"
+                    },
+                    {
+                        "word": "as",
+                        "start": 57.23,
+                        "end": 57.39,
+                        "confidence": 0.6142578,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "as"
+                    },
+                    {
+                        "word": "well",
+                        "start": 57.39,
+                        "end": 57.55,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "well"
+                    },
+                    {
+                        "word": "as",
+                        "start": 57.55,
+                        "end": 57.79,
+                        "confidence": 0.99853516,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "as"
+                    },
+                    {
+                        "word": "anderson",
+                        "start": 57.79,
+                        "end": 58.11,
+                        "confidence": 0.8964844,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "Anderson"
+                    },
+                    {
+                        "word": "cooper",
+                        "start": 58.11,
+                        "end": 58.585,
+                        "confidence": 0.7988281,
+                        "speaker": 0,
+                        "speaker_confidence": 0.60973746,
+                        "punctuated_word": "Cooper."
+                    },
+                    {
+                        "word": "to",
+                        "start": 58.905,
+                        "end": 59.065,
+                        "confidence": 0.47143555,
+                        "speaker": 0,
+                        "speaker_confidence": 0.30368042,
+                        "punctuated_word": "To"
+                    },
+                    {
+                        "word": "stay",
+                        "start": 59.065,
+                        "end": 59.225,
+                        "confidence": 0.9975586,
+                        "speaker": 0,
+                        "speaker_confidence": 0.30368042,
+                        "punctuated_word": "stay"
+                    },
+                    {
+                        "word": "up",
+                        "start": 59.225,
+                        "end": 59.385,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.30368042,
+                        "punctuated_word": "up"
+                    },
+                    {
+                        "word": "to",
+                        "start": 59.385,
+                        "end": 59.545,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.30368042,
+                        "punctuated_word": "to"
+                    },
+                    {
+                        "word": "date",
+                        "start": 59.545,
+                        "end": 59.704998,
+                        "confidence": 1.0,
+                        "speaker": 0,
+                        "speaker_confidence": 0.30368042,
+                        "punctuated_word": "date"
+                    },
+                    {
+                        "word": "on",
+                        "start": 59.704998,
+                        "end": 59.864998,
+                        "confidence": 0.9970703,
+                        "speaker": 0,
+                        "speaker_confidence": 0.30368042,
+                        "punctuated_word": "on"
+                    },
+                    {
+                        "word": "this",
+                        "start": 59.864998,
+                        "end": 59.945,
+                        "confidence": 0.56152344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "this"
+                    },
+                    {
+                        "word": "story",
+                        "start": 59.945,
+                        "end": 60.265,
+                        "confidence": 0.94433594,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "story,"
+                    },
+                    {
+                        "word": "hit",
+                        "start": 60.265,
+                        "end": 60.504997,
+                        "confidence": 0.9506836,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "hit"
+                    },
+                    {
+                        "word": "the",
+                        "start": 60.504997,
+                        "end": 60.665,
+                        "confidence": 0.4946289,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "thr",
+                        "start": 60.665,
+                        "end": 61.065,
+                        "confidence": 0.9326172,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "thr"
+                    },
+                    {
+                        "word": "dot",
+                        "start": 61.065,
+                        "end": 61.305,
+                        "confidence": 0.984375,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "dot"
+                    },
+                    {
+                        "word": "com",
+                        "start": 61.305,
+                        "end": 61.545,
+                        "confidence": 0.71813965,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "com,"
+                    },
+                    {
+                        "word": "and",
+                        "start": 61.545,
+                        "end": 61.785,
+                        "confidence": 0.99902344,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "and"
+                    },
+                    {
+                        "word": "until",
+                        "start": 61.785,
+                        "end": 62.105,
+                        "confidence": 0.9980469,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "until"
+                    },
+                    {
+                        "word": "next",
+                        "start": 62.105,
+                        "end": 62.265,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "next"
+                    },
+                    {
+                        "word": "time",
+                        "start": 62.265,
+                        "end": 62.425,
+                        "confidence": 0.9995117,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "time"
+                    },
+                    {
+                        "word": "for",
+                        "start": 62.425,
+                        "end": 62.585,
+                        "confidence": 0.9550781,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "for"
+                    },
+                    {
+                        "word": "the",
+                        "start": 62.585,
+                        "end": 62.665,
+                        "confidence": 0.96484375,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "the"
+                    },
+                    {
+                        "word": "hollywood",
+                        "start": 62.665,
+                        "end": 63.065,
+                        "confidence": 0.9711914,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "Hollywood"
+                    },
+                    {
+                        "word": "reporter",
+                        "start": 63.065,
+                        "end": 63.385,
+                        "confidence": 0.9604492,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "reporter"
+                    },
+                    {
+                        "word": "news",
+                        "start": 63.385,
+                        "end": 63.704998,
+                        "confidence": 0.76586914,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "news,"
+                    },
+                    {
+                        "word": "i",
+                        "start": 63.704998,
+                        "end": 63.785,
+                        "confidence": 0.72021484,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "I"
+                    },
+                    {
+                        "word": "may",
+                        "start": 63.785,
+                        "end": 63.945,
+                        "confidence": 0.86083984,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "may"
+                    },
+                    {
+                        "word": "enjoy",
+                        "start": 63.945,
+                        "end": 64.445,
+                        "confidence": 0.75561523,
+                        "speaker": 0,
+                        "speaker_confidence": 0.57561845,
+                        "punctuated_word": "enjoy."
+                    }
+                ],
+                "speaker": 0,
+                "id": "6665ed62-e038-4bf1-87ad-95430518e4c0"
+            }
+        ]
+    }
+}

--- a/data/revai_sample.json
+++ b/data/revai_sample.json
@@ -1,0 +1,2354 @@
+{
+    "monologues": [
+        {
+            "speaker": 0,
+            "elements": [
+                {
+                    "type": "text",
+                    "value": "C",
+                    "ts": 0.4,
+                    "end_ts": 0.52,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "n",
+                    "ts": 0.52,
+                    "end_ts": 0.64,
+                    "confidence": 0.89
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "n",
+                    "ts": 0.64,
+                    "end_ts": 0.76,
+                    "confidence": 0.82
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "has",
+                    "ts": 0.76,
+                    "end_ts": 0.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "decided",
+                    "ts": 0.96,
+                    "end_ts": 1.32,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "not",
+                    "ts": 1.42,
+                    "end_ts": 1.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 1.64,
+                    "end_ts": 1.76,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "run",
+                    "ts": 1.76,
+                    "end_ts": 1.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "a",
+                    "ts": 2.08,
+                    "end_ts": 2.2,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Donald Trump",
+                    "ts": 2.2,
+                    "end_ts": 2.68,
+                    "confidence": 0.86
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "endorsed",
+                    "ts": 2.68,
+                    "end_ts": 3.2,
+                    "confidence": 0.85
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "campaign",
+                    "ts": 3.44,
+                    "end_ts": 3.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "ad",
+                    "ts": 3.78,
+                    "end_ts": 4.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "after",
+                    "ts": 4.0,
+                    "end_ts": 4.24,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 4.26,
+                    "end_ts": 4.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "network",
+                    "ts": 4.48,
+                    "end_ts": 4.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "decided",
+                    "ts": 4.67,
+                    "end_ts": 5.16,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "it",
+                    "ts": 5.26,
+                    "end_ts": 5.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "does",
+                    "ts": 5.48,
+                    "end_ts": 5.68,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "not",
+                    "ts": 5.68,
+                    "end_ts": 5.84,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "meet",
+                    "ts": 5.84,
+                    "end_ts": 6.08,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "their",
+                    "ts": 6.08,
+                    "end_ts": 6.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "standards",
+                    "ts": 6.44,
+                    "end_ts": 6.76,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                }
+            ]
+        },
+        {
+            "speaker": 0,
+            "elements": [
+                {
+                    "type": "text",
+                    "value": "The",
+                    "ts": 8.5,
+                    "end_ts": 8.72,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "32nd",
+                    "ts": 8.72,
+                    "end_ts": 9.2,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "advertisement",
+                    "ts": 9.2,
+                    "end_ts": 10.04,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "paid",
+                    "ts": 10.04,
+                    "end_ts": 10.32,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "for",
+                    "ts": 10.32,
+                    "end_ts": 10.52,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "by",
+                    "ts": 10.54,
+                    "end_ts": 10.76,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Trump's",
+                    "ts": 10.76,
+                    "end_ts": 11.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "campaign",
+                    "ts": 11.32,
+                    "end_ts": 11.52,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "targeted",
+                    "ts": 12.04,
+                    "end_ts": 12.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Joe",
+                    "ts": 12.22,
+                    "end_ts": 12.44,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Biden's",
+                    "ts": 12.47,
+                    "end_ts": 12.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "conduct",
+                    "ts": 12.96,
+                    "end_ts": 13.2,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "toward",
+                    "ts": 13.2,
+                    "end_ts": 13.6,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Ukraine",
+                    "ts": 13.6,
+                    "end_ts": 14.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "while",
+                    "ts": 14.09,
+                    "end_ts": 14.44,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "he",
+                    "ts": 14.44,
+                    "end_ts": 14.6,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "served",
+                    "ts": 14.6,
+                    "end_ts": 14.8,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "as",
+                    "ts": 14.82,
+                    "end_ts": 15.04,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "vice",
+                    "ts": 15.04,
+                    "end_ts": 15.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "president",
+                    "ts": 15.28,
+                    "end_ts": 15.68,
+                    "confidence": 0.89
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "while",
+                    "ts": 15.73,
+                    "end_ts": 16.08,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "also",
+                    "ts": 16.08,
+                    "end_ts": 16.32,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "referring",
+                    "ts": 16.32,
+                    "end_ts": 16.76,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 16.76,
+                    "end_ts": 16.84,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "C",
+                    "ts": 16.96,
+                    "end_ts": 17.08,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 17.08,
+                    "end_ts": 17.2,
+                    "confidence": 0.88
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 17.2,
+                    "end_ts": 17.28,
+                    "confidence": 0.86
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "personalities",
+                    "ts": 17.28,
+                    "end_ts": 17.88,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Don",
+                    "ts": 18.18,
+                    "end_ts": 18.4,
+                    "confidence": 0.92
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Lemon",
+                    "ts": 18.4,
+                    "end_ts": 18.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Chris",
+                    "ts": 18.93,
+                    "end_ts": 19.28,
+                    "confidence": 0.95
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Cuomo",
+                    "ts": 19.57,
+                    "end_ts": 19.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "and",
+                    "ts": 20.1,
+                    "end_ts": 20.32,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Jim",
+                    "ts": 20.38,
+                    "end_ts": 20.6,
+                    "confidence": 0.96
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Acosta",
+                    "ts": 20.74,
+                    "end_ts": 21.16,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "as",
+                    "ts": 21.16,
+                    "end_ts": 21.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "media",
+                    "ts": 21.36,
+                    "end_ts": 21.6,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Lapdog",
+                    "ts": 21.86,
+                    "end_ts": 22.28,
+                    "confidence": 0.91
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "A",
+                    "ts": 22.8,
+                    "end_ts": 22.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "C",
+                    "ts": 23.0,
+                    "end_ts": 23.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 23.12,
+                    "end_ts": 23.24,
+                    "confidence": 0.85
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 23.24,
+                    "end_ts": 23.36,
+                    "confidence": 0.79
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "spokesperson",
+                    "ts": 23.36,
+                    "end_ts": 23.88,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "spoke",
+                    "ts": 23.93,
+                    "end_ts": 24.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 24.28,
+                    "end_ts": 24.4,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "T",
+                    "ts": 24.52,
+                    "end_ts": 24.6,
+                    "confidence": 0.82
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "H",
+                    "ts": 24.64,
+                    "end_ts": 24.76,
+                    "confidence": 0.93
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "R",
+                    "ts": 24.8,
+                    "end_ts": 24.92,
+                    "confidence": 0.91
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "saying",
+                    "ts": 24.92,
+                    "end_ts": 25.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 25.28,
+                    "end_ts": 25.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "ad",
+                    "ts": 25.5,
+                    "end_ts": 25.72,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "does",
+                    "ts": 25.72,
+                    "end_ts": 25.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "not",
+                    "ts": 25.96,
+                    "end_ts": 26.16,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "meet",
+                    "ts": 26.16,
+                    "end_ts": 26.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 26.36,
+                    "end_ts": 26.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "network's",
+                    "ts": 26.48,
+                    "end_ts": 26.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "advertising",
+                    "ts": 27.16,
+                    "end_ts": 27.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "standards",
+                    "ts": 27.68,
+                    "end_ts": 28.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "adding",
+                    "ts": 28.0,
+                    "end_ts": 28.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "in",
+                    "ts": 28.7,
+                    "end_ts": 28.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "addition",
+                    "ts": 29.12,
+                    "end_ts": 29.2,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 29.2,
+                    "end_ts": 29.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "disparaging",
+                    "ts": 29.36,
+                    "end_ts": 29.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "C",
+                    "ts": 30.08,
+                    "end_ts": 30.2,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 30.2,
+                    "end_ts": 30.32,
+                    "confidence": 0.77
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 30.32,
+                    "end_ts": 30.44,
+                    "confidence": 0.78
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "and",
+                    "ts": 30.44,
+                    "end_ts": 30.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "its",
+                    "ts": 30.7,
+                    "end_ts": 30.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "journalists",
+                    "ts": 30.92,
+                    "end_ts": 31.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 31.46,
+                    "end_ts": 31.68,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "ad",
+                    "ts": 31.68,
+                    "end_ts": 31.88,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "makes",
+                    "ts": 31.88,
+                    "end_ts": 32.08,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "assertions",
+                    "ts": 32.08,
+                    "end_ts": 32.56,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "that",
+                    "ts": 32.56,
+                    "end_ts": 32.72,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "have",
+                    "ts": 32.72,
+                    "end_ts": 32.88,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "been",
+                    "ts": 32.88,
+                    "end_ts": 33.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "proven",
+                    "ts": 33.0,
+                    "end_ts": 33.16,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "demonstrably",
+                    "ts": 33.52,
+                    "end_ts": 33.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "false",
+                    "ts": 33.96,
+                    "end_ts": 34.2,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "by",
+                    "ts": 34.22,
+                    "end_ts": 34.44,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "various",
+                    "ts": 34.44,
+                    "end_ts": 34.72,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "news",
+                    "ts": 34.75,
+                    "end_ts": 35.04,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "outlets",
+                    "ts": 35.04,
+                    "end_ts": 35.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "including",
+                    "ts": 35.48,
+                    "end_ts": 36.04,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "C",
+                    "ts": 36.24,
+                    "end_ts": 36.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 36.4,
+                    "end_ts": 36.52,
+                    "confidence": 0.81
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "N",
+                    "ts": 36.52,
+                    "end_ts": 36.64,
+                    "confidence": 0.71
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "However",
+                    "ts": 36.64,
+                    "end_ts": 37.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "despite",
+                    "ts": 37.15,
+                    "end_ts": 37.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "CNN's",
+                    "ts": 38.01,
+                    "end_ts": 38.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "rejection",
+                    "ts": 38.36,
+                    "end_ts": 38.72,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 38.74,
+                    "end_ts": 38.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "President",
+                    "ts": 38.96,
+                    "end_ts": 39.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "posted",
+                    "ts": 39.28,
+                    "end_ts": 39.56,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 39.62,
+                    "end_ts": 39.84,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "advertisement",
+                    "ts": 39.84,
+                    "end_ts": 40.44,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "onto",
+                    "ts": 40.44,
+                    "end_ts": 40.64,
+                    "confidence": 0.97
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "his",
+                    "ts": 40.66,
+                    "end_ts": 40.88,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Twitter",
+                    "ts": 40.88,
+                    "end_ts": 41.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "page",
+                    "ts": 41.19,
+                    "end_ts": 41.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "last",
+                    "ts": 41.51,
+                    "end_ts": 41.8,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "week",
+                    "ts": 41.8,
+                    "end_ts": 42.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "along",
+                    "ts": 42.21,
+                    "end_ts": 42.56,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "with",
+                    "ts": 42.56,
+                    "end_ts": 42.72,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 42.72,
+                    "end_ts": 42.88,
+                    "confidence": 0.86
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "caption",
+                    "ts": 42.88,
+                    "end_ts": 43.2,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "I'm",
+                    "ts": 43.34,
+                    "end_ts": 43.56,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "draining",
+                    "ts": 43.56,
+                    "end_ts": 43.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 43.96,
+                    "end_ts": 44.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "swamp",
+                    "ts": 44.12,
+                    "end_ts": 44.4,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Now",
+                    "ts": 44.7,
+                    "end_ts": 44.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "This",
+                    "ts": 44.92,
+                    "end_ts": 45.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "is",
+                    "ts": 45.12,
+                    "end_ts": 45.24,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "not",
+                    "ts": 45.26,
+                    "end_ts": 45.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 45.48,
+                    "end_ts": 45.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "first",
+                    "ts": 45.64,
+                    "end_ts": 45.8,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "time",
+                    "ts": 45.8,
+                    "end_ts": 46.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "c",
+                    "ts": 46.12,
+                    "end_ts": 46.24,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "n",
+                    "ts": 46.24,
+                    "end_ts": 46.36,
+                    "confidence": 0.81
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "n",
+                    "ts": 46.36,
+                    "end_ts": 46.48,
+                    "confidence": 0.84
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "has",
+                    "ts": 46.48,
+                    "end_ts": 46.64,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "rejected",
+                    "ts": 46.84,
+                    "end_ts": 47.0,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "a",
+                    "ts": 47.2,
+                    "end_ts": 47.32,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Trump",
+                    "ts": 47.32,
+                    "end_ts": 47.52,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "campaign",
+                    "ts": 47.84,
+                    "end_ts": 48.04,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "ad",
+                    "ts": 48.14,
+                    "end_ts": 48.36,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Back",
+                    "ts": 48.51,
+                    "end_ts": 48.8,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "in",
+                    "ts": 48.8,
+                    "end_ts": 48.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "2017",
+                    "ts": 48.92,
+                    "end_ts": 49.52,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 49.54,
+                    "end_ts": 49.76,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "network",
+                    "ts": 49.76,
+                    "end_ts": 49.92,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "refused",
+                    "ts": 49.95,
+                    "end_ts": 50.44,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 50.44,
+                    "end_ts": 50.6,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "run",
+                    "ts": 50.6,
+                    "end_ts": 50.76,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "a",
+                    "ts": 50.84,
+                    "end_ts": 50.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Trump",
+                    "ts": 50.96,
+                    "end_ts": 51.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "approved",
+                    "ts": 51.4,
+                    "end_ts": 51.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "ad",
+                    "ts": 51.62,
+                    "end_ts": 51.84,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "called",
+                    "ts": 51.84,
+                    "end_ts": 52.08,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Let",
+                    "ts": 52.34,
+                    "end_ts": 52.56,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "President",
+                    "ts": 52.56,
+                    "end_ts": 52.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Trump",
+                    "ts": 52.96,
+                    "end_ts": 53.16,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "do",
+                    "ts": 53.22,
+                    "end_ts": 53.44,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "his",
+                    "ts": 53.44,
+                    "end_ts": 53.56,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "job",
+                    "ts": 53.58,
+                    "end_ts": 53.8,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "which",
+                    "ts": 54.05,
+                    "end_ts": 54.4,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "criticized",
+                    "ts": 54.4,
+                    "end_ts": 54.96,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 54.96,
+                    "end_ts": 55.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "media",
+                    "ts": 55.12,
+                    "end_ts": 55.28,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "and",
+                    "ts": 55.46,
+                    "end_ts": 55.68,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "specifically",
+                    "ts": 55.92,
+                    "end_ts": 56.24,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "called",
+                    "ts": 56.24,
+                    "end_ts": 56.48,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "out",
+                    "ts": 56.68,
+                    "end_ts": 56.84,
+                    "confidence": 0.94
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Lemon",
+                    "ts": 56.84,
+                    "end_ts": 57.08,
+                    "confidence": 0.94
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "as",
+                    "ts": 57.22,
+                    "end_ts": 57.44,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "well",
+                    "ts": 57.44,
+                    "end_ts": 57.6,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "as",
+                    "ts": 57.6,
+                    "end_ts": 57.72,
+                    "confidence": 0.96
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Anderson",
+                    "ts": 57.92,
+                    "end_ts": 58.12,
+                    "confidence": 0.99
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Cooper",
+                    "ts": 58.12,
+                    "end_ts": 58.4,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "So",
+                    "ts": 58.86,
+                    "end_ts": 59.08,
+                    "confidence": 0.46
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "stay",
+                    "ts": 59.08,
+                    "end_ts": 59.28,
+                    "confidence": 0.97
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "up",
+                    "ts": 59.28,
+                    "end_ts": 59.4,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 59.4,
+                    "end_ts": 59.48,
+                    "confidence": 0.89
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "date",
+                    "ts": 59.48,
+                    "end_ts": 59.64,
+                    "confidence": 0.87
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "on",
+                    "ts": 59.64,
+                    "end_ts": 59.8,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 59.8,
+                    "end_ts": 59.92,
+                    "confidence": 0.59
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "story",
+                    "ts": 59.92,
+                    "end_ts": 60.12,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Hit",
+                    "ts": 60.18,
+                    "end_ts": 60.4,
+                    "confidence": 0.63
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "to",
+                    "ts": 60.4,
+                    "end_ts": 60.52,
+                    "confidence": 0.87
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "thr.com",
+                    "ts": 60.78,
+                    "end_ts": 61.6,
+                    "confidence": 0.43
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "and",
+                    "ts": 61.6,
+                    "end_ts": 61.8,
+                    "confidence": 0.94
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "until",
+                    "ts": 61.8,
+                    "end_ts": 62.08,
+                    "confidence": 0.95
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "next",
+                    "ts": 62.08,
+                    "end_ts": 62.28,
+                    "confidence": 0.97
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "time",
+                    "ts": 62.28,
+                    "end_ts": 62.44,
+                    "confidence": 0.97
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "for",
+                    "ts": 62.44,
+                    "end_ts": 62.6,
+                    "confidence": 0.94
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "the",
+                    "ts": 62.6,
+                    "end_ts": 62.68,
+                    "confidence": 0.93
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Hollywood",
+                    "ts": 62.68,
+                    "end_ts": 63.0,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Reporter",
+                    "ts": 63.2,
+                    "end_ts": 63.28,
+                    "confidence": 0.98
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "News",
+                    "ts": 63.31,
+                    "end_ts": 63.6,
+                    "confidence": 0.95
+                },
+                {
+                    "type": "punct",
+                    "value": ","
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Emma",
+                    "ts": 63.63,
+                    "end_ts": 63.92,
+                    "confidence": 0.32
+                },
+                {
+                    "type": "punct",
+                    "value": " "
+                },
+                {
+                    "type": "text",
+                    "value": "Hijo",
+                    "ts": 63.95,
+                    "end_ts": 64.24,
+                    "confidence": 0.51
+                },
+                {
+                    "type": "punct",
+                    "value": "."
+                }
+            ]
+        }
+    ]
+}

--- a/data/speechmatics_sample.json
+++ b/data/speechmatics_sample.json
@@ -1,0 +1,2799 @@
+{
+    "format": "2.9",
+    "job": {
+        "created_at": "2023-08-21T19:13:18.569Z",
+        "data_name": "abjxc.wav",
+        "duration": 68,
+        "id": "g0545zrvcp"
+    },
+    "metadata": {
+        "created_at": "2023-08-21T19:13:42.840321Z",
+        "language_pack_info": {
+            "adapted": false,
+            "itn": true,
+            "language_description": "English",
+            "word_delimiter": " ",
+            "writing_direction": "left-to-right"
+        },
+        "transcription_config": {
+            "diarization": "speaker",
+            "language": "en",
+            "operating_point": "enhanced"
+        },
+        "type": "transcription"
+    },
+    "results": [
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 0.71,
+            "start_time": 0.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "has",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 0.89,
+            "start_time": 0.71,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "decided",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 1.4,
+            "start_time": 0.89,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "not",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 1.67,
+            "start_time": 1.4,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "to",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 1.79,
+            "start_time": 1.67,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "run",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 2.06,
+            "start_time": 1.79,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "a",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 2.15,
+            "start_time": 2.06,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Donald",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 2.45,
+            "start_time": 2.15,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Trump",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 2.75,
+            "start_time": 2.48,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.94,
+                    "content": "endorsed",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 3.14,
+            "start_time": 2.75,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "campaign",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 3.71,
+            "start_time": 3.14,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "ad",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 3.98,
+            "start_time": 3.71,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "after",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 4.34,
+            "start_time": 3.98,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 4.43,
+            "start_time": 4.34,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "network",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 4.76,
+            "start_time": 4.43,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "decided",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 5.27,
+            "start_time": 4.76,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "it",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 5.42,
+            "start_time": 5.27,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "does",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 5.63,
+            "start_time": 5.42,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "not",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 5.87,
+            "start_time": 5.63,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "meet",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 6.05,
+            "start_time": 5.87,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "their",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 6.23,
+            "start_time": 6.05,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "standards",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 7.16,
+            "start_time": 6.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 7.16,
+            "is_eos": true,
+            "start_time": 7.16,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.98,
+                    "content": "The",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 8.75,
+            "start_time": 8.39,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "32nd",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 9.35,
+            "start_time": 8.75,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "advertisement",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 10.07,
+            "start_time": 9.35,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "paid",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 10.34,
+            "start_time": 10.07,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "for",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 10.55,
+            "start_time": 10.34,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "by",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 10.73,
+            "start_time": 10.55,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Trump's",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 11.03,
+            "start_time": 10.73,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "campaign",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 11.72,
+            "start_time": 11.03,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "targeted",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 12.23,
+            "start_time": 11.72,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Joe",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 12.44,
+            "start_time": 12.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Biden's",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 12.86,
+            "start_time": 12.44,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "conduct",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 13.34,
+            "start_time": 12.86,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "toward",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 13.64,
+            "start_time": 13.34,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Ukraine",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 14.21,
+            "start_time": 13.64,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "while",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 14.48,
+            "start_time": 14.21,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "he",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 14.63,
+            "start_time": 14.48,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "served",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 14.99,
+            "start_time": 14.63,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "as",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 15.14,
+            "start_time": 14.99,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "vice",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 15.38,
+            "start_time": 15.14,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "president",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 15.95,
+            "start_time": 15.38,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 15.95,
+            "is_eos": false,
+            "start_time": 15.95,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "while",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 16.25,
+            "start_time": 15.95,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "also",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 16.58,
+            "start_time": 16.25,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "referring",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 16.97,
+            "start_time": 16.58,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "to",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 17.12,
+            "start_time": 17.0,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 17.48,
+            "start_time": 17.12,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "personalities",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 18.29,
+            "start_time": 17.51,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Don",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 18.56,
+            "start_time": 18.29,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Lemon",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 19.07,
+            "start_time": 18.56,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 19.07,
+            "is_eos": false,
+            "start_time": 19.07,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Chris",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 19.4,
+            "start_time": 19.07,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Cuomo",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 20.0,
+            "start_time": 19.43,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "and",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 20.39,
+            "start_time": 20.0,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Jim",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 20.6,
+            "start_time": 20.39,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Acosta",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 21.08,
+            "start_time": 20.6,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "as",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 21.35,
+            "start_time": 21.11,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "media",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 21.71,
+            "start_time": 21.35,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "lapdogs",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 22.67,
+            "start_time": 21.71,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 22.67,
+            "is_eos": true,
+            "start_time": 22.67,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "A",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 22.94,
+            "start_time": 22.7,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 23.3,
+            "start_time": 22.94,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "spokesperson",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 23.99,
+            "start_time": 23.3,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "spoke",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 24.29,
+            "start_time": 23.99,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.99,
+                    "content": "to",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 24.41,
+            "start_time": 24.29,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.23,
+                    "content": "SR",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 24.87,
+            "start_time": 24.68,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "saying",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 25.31,
+            "start_time": 24.98,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 25.49,
+            "start_time": 25.31,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "ad",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 25.73,
+            "start_time": 25.49,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "does",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 25.94,
+            "start_time": 25.73,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "not",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 26.18,
+            "start_time": 25.94,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "meet",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 26.36,
+            "start_time": 26.18,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 26.45,
+            "start_time": 26.36,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "network's",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 26.87,
+            "start_time": 26.45,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "advertising",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 27.47,
+            "start_time": 26.87,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "standards",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 28.1,
+            "start_time": 27.47,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 28.1,
+            "is_eos": false,
+            "start_time": 28.1,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "adding",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 28.67,
+            "start_time": 28.1,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "In",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 28.88,
+            "start_time": 28.67,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "addition",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 29.24,
+            "start_time": 28.88,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "to",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 29.36,
+            "start_time": 29.24,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "disparaging",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 29.99,
+            "start_time": 29.36,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 30.41,
+            "start_time": 29.99,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "and",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 30.68,
+            "start_time": 30.41,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "its",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 30.83,
+            "start_time": 30.68,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "journalists",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 31.4,
+            "start_time": 30.83,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 31.4,
+            "is_eos": false,
+            "start_time": 31.4,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 31.7,
+            "start_time": 31.4,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "ad",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 31.91,
+            "start_time": 31.7,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "makes",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 32.12,
+            "start_time": 31.91,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "assertions",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 32.6,
+            "start_time": 32.12,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "that",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 32.75,
+            "start_time": 32.6,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "have",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 32.84,
+            "start_time": 32.75,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "been",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 32.99,
+            "start_time": 32.84,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "proven",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 33.38,
+            "start_time": 32.99,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "demonstrably",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 34.13,
+            "start_time": 33.38,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "false",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 34.46,
+            "start_time": 34.13,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "by",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 34.67,
+            "start_time": 34.46,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "various",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 35.09,
+            "start_time": 34.67,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "news",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 35.33,
+            "start_time": 35.09,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "outlets",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 35.78,
+            "start_time": 35.33,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 35.78,
+            "is_eos": false,
+            "start_time": 35.78,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "including",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 36.38,
+            "start_time": 35.81,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 36.92,
+            "start_time": 36.38,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 36.92,
+            "is_eos": true,
+            "start_time": 36.92,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "However",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 37.4,
+            "start_time": 36.95,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 37.4,
+            "is_eos": false,
+            "start_time": 37.4,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "despite",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 37.79,
+            "start_time": 37.4,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN's",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 38.18,
+            "start_time": 37.79,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "rejection",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 38.78,
+            "start_time": 38.18,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 38.78,
+            "is_eos": false,
+            "start_time": 38.78,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 38.9,
+            "start_time": 38.78,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "president",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 39.32,
+            "start_time": 38.9,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "posted",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 39.71,
+            "start_time": 39.32,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 39.8,
+            "start_time": 39.71,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "advertisement",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 40.49,
+            "start_time": 39.8,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.99,
+                    "content": "onto",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 40.73,
+            "start_time": 40.49,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "his",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 40.85,
+            "start_time": 40.73,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Twitter",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 41.15,
+            "start_time": 40.85,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "page",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 41.51,
+            "start_time": 41.15,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "last",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 41.81,
+            "start_time": 41.51,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "week",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 42.2,
+            "start_time": 41.81,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 42.2,
+            "is_eos": false,
+            "start_time": 42.2,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "along",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 42.56,
+            "start_time": 42.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "with",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 42.68,
+            "start_time": 42.56,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 42.77,
+            "start_time": 42.68,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "caption",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 43.31,
+            "start_time": 42.77,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 43.31,
+            "is_eos": false,
+            "start_time": 43.31,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.84,
+                    "content": "I'm",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 43.55,
+            "start_time": 43.31,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "draining",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 43.94,
+            "start_time": 43.55,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 44.06,
+            "start_time": 43.94,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "swamp",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 44.59,
+            "start_time": 44.06,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Now",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 44.9,
+            "start_time": 44.6,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 44.9,
+            "is_eos": true,
+            "start_time": 44.9,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "This",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 45.08,
+            "start_time": 44.9,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "is",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 45.23,
+            "start_time": 45.08,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "not",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 45.5,
+            "start_time": 45.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 45.59,
+            "start_time": 45.5,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "first",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 45.86,
+            "start_time": 45.59,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "time",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 46.07,
+            "start_time": 45.86,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "CNN",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 46.4,
+            "start_time": 46.07,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "has",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 46.61,
+            "start_time": 46.4,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "rejected",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 47.15,
+            "start_time": 46.61,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "a",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 47.27,
+            "start_time": 47.15,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Trump",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 47.6,
+            "start_time": 47.27,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "campaign",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 48.11,
+            "start_time": 47.6,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "ad",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 48.52,
+            "start_time": 48.11,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 48.52,
+            "is_eos": true,
+            "start_time": 48.52,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Back",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 48.8,
+            "start_time": 48.53,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "in",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 48.89,
+            "start_time": 48.8,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "2017",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 49.61,
+            "start_time": 48.89,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 49.61,
+            "is_eos": false,
+            "start_time": 49.61,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 49.73,
+            "start_time": 49.64,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "network",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 50.06,
+            "start_time": 49.73,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "refused",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 50.51,
+            "start_time": 50.06,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "to",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 50.63,
+            "start_time": 50.51,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "run",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 50.84,
+            "start_time": 50.63,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "a",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 50.93,
+            "start_time": 50.84,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Trump",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 51.23,
+            "start_time": 50.93,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "approved",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 51.62,
+            "start_time": 51.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "ad",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 51.89,
+            "start_time": 51.62,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "called",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 52.4,
+            "start_time": 51.89,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Let",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 52.7,
+            "start_time": 52.4,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "President",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 53.15,
+            "start_time": 52.73,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Trump",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 53.42,
+            "start_time": 53.15,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Do",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 53.6,
+            "start_time": 53.42,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "His",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 53.78,
+            "start_time": 53.6,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Job",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 54.29,
+            "start_time": 53.78,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 54.29,
+            "is_eos": false,
+            "start_time": 54.29,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "which",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 54.59,
+            "start_time": 54.29,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.95,
+                    "content": "criticized",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 55.07,
+            "start_time": 54.59,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 55.13,
+            "start_time": 55.07,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "media",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 55.49,
+            "start_time": 55.13,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "and",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 55.76,
+            "start_time": 55.49,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "specifically",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 56.39,
+            "start_time": 55.76,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "called",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 56.69,
+            "start_time": 56.39,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "out",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 56.87,
+            "start_time": 56.69,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Lemon",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 57.23,
+            "start_time": 56.87,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 57.23,
+            "is_eos": false,
+            "start_time": 57.23,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "as",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 57.44,
+            "start_time": 57.23,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "well",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 57.62,
+            "start_time": 57.44,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "as",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 57.74,
+            "start_time": 57.62,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Anderson",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 58.13,
+            "start_time": 57.74,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Cooper",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 58.88,
+            "start_time": 58.13,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 58.88,
+            "is_eos": true,
+            "start_time": 58.88,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.99,
+                    "content": "To",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.09,
+            "start_time": 58.91,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "stay",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.27,
+            "start_time": 59.09,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "up",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.36,
+            "start_time": 59.27,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "to",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.45,
+            "start_time": 59.36,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "date",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.63,
+            "start_time": 59.45,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "on",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.78,
+            "start_time": 59.63,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.99,
+                    "content": "this",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 59.87,
+            "start_time": 59.78,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "story",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 60.36,
+            "start_time": 59.97,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.62,
+                    "content": "Hitc.com",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 61.8,
+            "start_time": 60.36,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 61.8,
+            "is_eos": true,
+            "start_time": 61.8,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "And",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 61.92,
+            "start_time": 61.8,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "until",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 62.19,
+            "start_time": 61.95,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "next",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 62.4,
+            "start_time": 62.19,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "time",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 62.58,
+            "start_time": 62.4,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "for",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 62.7,
+            "start_time": 62.58,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "the",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 62.79,
+            "start_time": 62.7,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Hollywood",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 63.09,
+            "start_time": 62.79,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "Reporter",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 63.45,
+            "start_time": 63.09,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "News",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 63.81,
+            "start_time": 63.45,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ",",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 63.81,
+            "is_eos": false,
+            "start_time": 63.81,
+            "type": "punctuation"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": "I'm",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 63.96,
+            "start_time": 63.81,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 0.93,
+                    "content": "Joy",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "end_time": 64.38,
+            "start_time": 64.11,
+            "type": "word"
+        },
+        {
+            "alternatives": [
+                {
+                    "confidence": 1.0,
+                    "content": ".",
+                    "language": "en",
+                    "speaker": "S1"
+                }
+            ],
+            "attaches_to": "previous",
+            "end_time": 64.38,
+            "is_eos": true,
+            "start_time": 64.38,
+            "type": "punctuation"
+        }
+    ]
+}

--- a/data/wordcab_sample.json
+++ b/data/wordcab_sample.json
@@ -1,0 +1,1192 @@
+{
+    "transcript_id": "file_transcript_G5KtbRTPK3QoPAVBunVbsF5HcZKLg3QH",
+    "job_id_set": [
+        "job_NZ8uSGUQzDMTchFmHyRf4Vqi3Bu4G9Vz"
+    ],
+    "summary_id_set": [],
+    "transcript": [
+        {
+            "end": "00:01:04",
+            "text": "CNN has decided not to run a Donald Trump-endorsed campaign ad after the network decided it does not meet their standards. The 30-second advertisement paid for by Trump's campaign targeted Joe Biden's conduct toward Ukraine while he served as vice president, while also referring to CNN personalities Don Lemon, Chris Cuomo, and Jim Acosta as media lapdogs. A CNN spokesperson spoke to THR, saying the ad does not meet the network's advertising standards, adding, in addition to disparaging CNN and its journalists, the ad makes assertions that have been proven demonstrably false by various news outlets, including CNN. However, despite CNN's rejection, the president posted the advertisement onto his Twitter page last week, along with the caption, I am draining the swamp. Now, this is not the first time CNN has rejected a Trump campaign ad. Back in 2017, the network refused to run a Trump-approved ad called Let President Trump Do His Job, which criticized the media and specifically called out Lemon as well as Anderson. To stay up to date on this story, head to thr.com, and until next time, for The Hollywood Reporter News, I'm Neha Joy.",
+            "start": "00:00:00",
+            "words": [
+                {
+                    "end": 0.64,
+                    "word": "CNN",
+                    "score": 0.82,
+                    "start": 0.32
+                },
+                {
+                    "end": 0.9,
+                    "word": "has",
+                    "score": 0.87,
+                    "start": 0.64
+                },
+                {
+                    "end": 1.34,
+                    "word": "decided",
+                    "score": 0.87,
+                    "start": 0.9
+                },
+                {
+                    "end": 1.64,
+                    "word": "not",
+                    "score": 0.86,
+                    "start": 1.34
+                },
+                {
+                    "end": 1.82,
+                    "word": "to",
+                    "score": 0.9,
+                    "start": 1.64
+                },
+                {
+                    "end": 2.04,
+                    "word": "run",
+                    "score": 0.9,
+                    "start": 1.82
+                },
+                {
+                    "end": 2.22,
+                    "word": "a",
+                    "score": 1,
+                    "start": 2.04
+                },
+                {
+                    "end": 2.44,
+                    "word": "Donald",
+                    "score": 0.81,
+                    "start": 2.22
+                },
+                {
+                    "end": 2.76,
+                    "word": "Trump",
+                    "score": 0.85,
+                    "start": 2.44
+                },
+                {
+                    "end": 3.16,
+                    "word": "-endorsed",
+                    "score": 0.77,
+                    "start": 2.76
+                },
+                {
+                    "end": 3.66,
+                    "word": "campaign",
+                    "score": 0.82,
+                    "start": 3.16
+                },
+                {
+                    "end": 3.98,
+                    "word": "ad",
+                    "score": 0.91,
+                    "start": 3.66
+                },
+                {
+                    "end": 4.34,
+                    "word": "after",
+                    "score": 0.7,
+                    "start": 3.98
+                },
+                {
+                    "end": 4.5,
+                    "word": "the",
+                    "score": 0.78,
+                    "start": 4.34
+                },
+                {
+                    "end": 4.72,
+                    "word": "network",
+                    "score": 0.82,
+                    "start": 4.5
+                },
+                {
+                    "end": 5.22,
+                    "word": "decided",
+                    "score": 0.86,
+                    "start": 4.72
+                },
+                {
+                    "end": 5.44,
+                    "word": "it",
+                    "score": 0.88,
+                    "start": 5.22
+                },
+                {
+                    "end": 5.64,
+                    "word": "does",
+                    "score": 0.84,
+                    "start": 5.44
+                },
+                {
+                    "end": 5.88,
+                    "word": "not",
+                    "score": 0.89,
+                    "start": 5.64
+                },
+                {
+                    "end": 6.08,
+                    "word": "meet",
+                    "score": 0.9,
+                    "start": 5.88
+                },
+                {
+                    "end": 6.24,
+                    "word": "their",
+                    "score": 0.89,
+                    "start": 6.08
+                },
+                {
+                    "end": 7.26,
+                    "word": "standards.",
+                    "score": 0.8,
+                    "start": 6.24
+                },
+                {
+                    "end": 8.78,
+                    "word": "The",
+                    "score": 0.73,
+                    "start": 8.58
+                },
+                {
+                    "end": 9.02,
+                    "word": "30",
+                    "score": 0.83,
+                    "start": 8.78
+                },
+                {
+                    "end": 9.32,
+                    "word": "-second",
+                    "score": 0.77,
+                    "start": 9.02
+                },
+                {
+                    "end": 9.92,
+                    "word": "advertisement",
+                    "score": 0.64,
+                    "start": 9.32
+                },
+                {
+                    "end": 10.32,
+                    "word": "paid",
+                    "score": 0.34,
+                    "start": 9.92
+                },
+                {
+                    "end": 10.54,
+                    "word": "for",
+                    "score": 0.87,
+                    "start": 10.32
+                },
+                {
+                    "end": 10.74,
+                    "word": "by",
+                    "score": 0.91,
+                    "start": 10.54
+                },
+                {
+                    "end": 11.1,
+                    "word": "Trump's",
+                    "score": 0.93,
+                    "start": 10.74
+                },
+                {
+                    "end": 11.6,
+                    "word": "campaign",
+                    "score": 0.81,
+                    "start": 11.1
+                },
+                {
+                    "end": 12.18,
+                    "word": "targeted",
+                    "score": 0.76,
+                    "start": 11.6
+                },
+                {
+                    "end": 12.48,
+                    "word": "Joe",
+                    "score": 0.81,
+                    "start": 12.18
+                },
+                {
+                    "end": 12.92,
+                    "word": "Biden's",
+                    "score": 0.97,
+                    "start": 12.48
+                },
+                {
+                    "end": 13.34,
+                    "word": "conduct",
+                    "score": 0.72,
+                    "start": 12.92
+                },
+                {
+                    "end": 13.62,
+                    "word": "toward",
+                    "score": 0.71,
+                    "start": 13.34
+                },
+                {
+                    "end": 14.12,
+                    "word": "Ukraine",
+                    "score": 0.88,
+                    "start": 13.62
+                },
+                {
+                    "end": 14.48,
+                    "word": "while",
+                    "score": 0.83,
+                    "start": 14.12
+                },
+                {
+                    "end": 14.64,
+                    "word": "he",
+                    "score": 0.91,
+                    "start": 14.48
+                },
+                {
+                    "end": 14.96,
+                    "word": "served",
+                    "score": 0.8,
+                    "start": 14.64
+                },
+                {
+                    "end": 15.18,
+                    "word": "as",
+                    "score": 0.91,
+                    "start": 14.96
+                },
+                {
+                    "end": 15.44,
+                    "word": "vice",
+                    "score": 0.73,
+                    "start": 15.18
+                },
+                {
+                    "end": 15.82,
+                    "word": "president,",
+                    "score": 0.74,
+                    "start": 15.44
+                },
+                {
+                    "end": 16.26,
+                    "word": "while",
+                    "score": 0.92,
+                    "start": 16.08
+                },
+                {
+                    "end": 16.6,
+                    "word": "also",
+                    "score": 0.82,
+                    "start": 16.26
+                },
+                {
+                    "end": 16.94,
+                    "word": "referring",
+                    "score": 0.82,
+                    "start": 16.6
+                },
+                {
+                    "end": 17.18,
+                    "word": "to",
+                    "score": 0.9,
+                    "start": 16.94
+                },
+                {
+                    "end": 17.46,
+                    "word": "CNN",
+                    "score": 0.89,
+                    "start": 17.18
+                },
+                {
+                    "end": 18.2,
+                    "word": "personalities",
+                    "score": 0.85,
+                    "start": 17.46
+                },
+                {
+                    "end": 18.58,
+                    "word": "Don",
+                    "score": 0.9,
+                    "start": 18.2
+                },
+                {
+                    "end": 18.9,
+                    "word": "Lemon,",
+                    "score": 0.88,
+                    "start": 18.58
+                },
+                {
+                    "end": 19.48,
+                    "word": "Chris",
+                    "score": 0.62,
+                    "start": 19.28
+                },
+                {
+                    "end": 19.84,
+                    "word": "Cuomo,",
+                    "score": 0.97,
+                    "start": 19.48
+                },
+                {
+                    "end": 20.46,
+                    "word": "and",
+                    "score": 0.89,
+                    "start": 20.18
+                },
+                {
+                    "end": 20.62,
+                    "word": "Jim",
+                    "score": 0.85,
+                    "start": 20.46
+                },
+                {
+                    "end": 21.04,
+                    "word": "Acosta",
+                    "score": 0.85,
+                    "start": 20.62
+                },
+                {
+                    "end": 21.36,
+                    "word": "as",
+                    "score": 0.89,
+                    "start": 21.04
+                },
+                {
+                    "end": 21.68,
+                    "word": "media",
+                    "score": 0.58,
+                    "start": 21.36
+                },
+                {
+                    "end": 22.5,
+                    "word": "lapdogs.",
+                    "score": 0.78,
+                    "start": 21.68
+                },
+                {
+                    "end": 23.02,
+                    "word": "A",
+                    "score": 0.99,
+                    "start": 22.88
+                },
+                {
+                    "end": 23.26,
+                    "word": "CNN",
+                    "score": 0.93,
+                    "start": 23.02
+                },
+                {
+                    "end": 23.88,
+                    "word": "spokesperson",
+                    "score": 0.81,
+                    "start": 23.26
+                },
+                {
+                    "end": 24.28,
+                    "word": "spoke",
+                    "score": 0.69,
+                    "start": 23.88
+                },
+                {
+                    "end": 24.44,
+                    "word": "to",
+                    "score": 0.9,
+                    "start": 24.28
+                },
+                {
+                    "end": 24.96,
+                    "word": "THR,",
+                    "score": 0.85,
+                    "start": 24.44
+                },
+                {
+                    "end": 25.28,
+                    "word": "saying",
+                    "score": 0.7,
+                    "start": 25.1
+                },
+                {
+                    "end": 25.46,
+                    "word": "the",
+                    "score": 0.8,
+                    "start": 25.28
+                },
+                {
+                    "end": 25.74,
+                    "word": "ad",
+                    "score": 0.92,
+                    "start": 25.46
+                },
+                {
+                    "end": 25.94,
+                    "word": "does",
+                    "score": 0.85,
+                    "start": 25.74
+                },
+                {
+                    "end": 26.2,
+                    "word": "not",
+                    "score": 0.87,
+                    "start": 25.94
+                },
+                {
+                    "end": 26.38,
+                    "word": "meet",
+                    "score": 0.9,
+                    "start": 26.2
+                },
+                {
+                    "end": 26.5,
+                    "word": "the",
+                    "score": 0.81,
+                    "start": 26.38
+                },
+                {
+                    "end": 26.94,
+                    "word": "network's",
+                    "score": 0.89,
+                    "start": 26.5
+                },
+                {
+                    "end": 27.38,
+                    "word": "advertising",
+                    "score": 0.91,
+                    "start": 26.94
+                },
+                {
+                    "end": 28.06,
+                    "word": "standards,",
+                    "score": 0.8,
+                    "start": 27.38
+                },
+                {
+                    "end": 28.44,
+                    "word": "adding,",
+                    "score": 0.77,
+                    "start": 28.14
+                },
+                {
+                    "end": 28.91,
+                    "word": "in",
+                    "score": 0.16,
+                    "start": 28.73
+                },
+                {
+                    "end": 29.17,
+                    "word": "addition",
+                    "score": 0.91,
+                    "start": 28.91
+                },
+                {
+                    "end": 29.39,
+                    "word": "to",
+                    "score": 0.91,
+                    "start": 29.17
+                },
+                {
+                    "end": 29.91,
+                    "word": "disparaging",
+                    "score": 0.94,
+                    "start": 29.39
+                },
+                {
+                    "end": 30.31,
+                    "word": "CNN",
+                    "score": 0.92,
+                    "start": 29.91
+                },
+                {
+                    "end": 30.69,
+                    "word": "and",
+                    "score": 0.89,
+                    "start": 30.31
+                },
+                {
+                    "end": 30.87,
+                    "word": "its",
+                    "score": 0.83,
+                    "start": 30.69
+                },
+                {
+                    "end": 31.33,
+                    "word": "journalists,",
+                    "score": 0.79,
+                    "start": 30.87
+                },
+                {
+                    "end": 31.67,
+                    "word": "the",
+                    "score": 0.71,
+                    "start": 31.33
+                },
+                {
+                    "end": 31.91,
+                    "word": "ad",
+                    "score": 0.89,
+                    "start": 31.67
+                },
+                {
+                    "end": 32.13,
+                    "word": "makes",
+                    "score": 0.7,
+                    "start": 31.91
+                },
+                {
+                    "end": 32.63,
+                    "word": "assertions",
+                    "score": 0.92,
+                    "start": 32.13
+                },
+                {
+                    "end": 32.79,
+                    "word": "that",
+                    "score": 0.88,
+                    "start": 32.63
+                },
+                {
+                    "end": 32.87,
+                    "word": "have",
+                    "score": 0.86,
+                    "start": 32.79
+                },
+                {
+                    "end": 33.01,
+                    "word": "been",
+                    "score": 0.76,
+                    "start": 32.87
+                },
+                {
+                    "end": 33.35,
+                    "word": "proven",
+                    "score": 0.86,
+                    "start": 33.01
+                },
+                {
+                    "end": 34.11,
+                    "word": "demonstrably",
+                    "score": 0.91,
+                    "start": 33.35
+                },
+                {
+                    "end": 34.45,
+                    "word": "false",
+                    "score": 0.85,
+                    "start": 34.11
+                },
+                {
+                    "end": 34.67,
+                    "word": "by",
+                    "score": 0.9,
+                    "start": 34.45
+                },
+                {
+                    "end": 35.09,
+                    "word": "various",
+                    "score": 0.87,
+                    "start": 34.67
+                },
+                {
+                    "end": 35.35,
+                    "word": "news",
+                    "score": 0.69,
+                    "start": 35.09
+                },
+                {
+                    "end": 35.73,
+                    "word": "outlets,",
+                    "score": 0.73,
+                    "start": 35.35
+                },
+                {
+                    "end": 36.31,
+                    "word": "including",
+                    "score": 0.77,
+                    "start": 35.97
+                },
+                {
+                    "end": 36.88,
+                    "word": "CNN.",
+                    "score": 0.93,
+                    "start": 36.31
+                },
+                {
+                    "end": 37.36,
+                    "word": "However,",
+                    "score": 0.84,
+                    "start": 37.12
+                },
+                {
+                    "end": 37.8,
+                    "word": "despite",
+                    "score": 0.76,
+                    "start": 37.46
+                },
+                {
+                    "end": 38.24,
+                    "word": "CNN's",
+                    "score": 0.96,
+                    "start": 37.8
+                },
+                {
+                    "end": 38.68,
+                    "word": "rejection,",
+                    "score": 0.7,
+                    "start": 38.24
+                },
+                {
+                    "end": 38.98,
+                    "word": "the",
+                    "score": 0.81,
+                    "start": 38.9
+                },
+                {
+                    "end": 39.22,
+                    "word": "president",
+                    "score": 0.68,
+                    "start": 38.98
+                },
+                {
+                    "end": 39.68,
+                    "word": "posted",
+                    "score": 0.78,
+                    "start": 39.22
+                },
+                {
+                    "end": 39.86,
+                    "word": "the",
+                    "score": 0.81,
+                    "start": 39.68
+                },
+                {
+                    "end": 40.38,
+                    "word": "advertisement",
+                    "score": 0.66,
+                    "start": 39.86
+                },
+                {
+                    "end": 40.7,
+                    "word": "onto",
+                    "score": 0.7,
+                    "start": 40.38
+                },
+                {
+                    "end": 40.9,
+                    "word": "his",
+                    "score": 0.9,
+                    "start": 40.7
+                },
+                {
+                    "end": 41.12,
+                    "word": "Twitter",
+                    "score": 0.85,
+                    "start": 40.9
+                },
+                {
+                    "end": 41.48,
+                    "word": "page",
+                    "score": 0.81,
+                    "start": 41.12
+                },
+                {
+                    "end": 41.82,
+                    "word": "last",
+                    "score": 0.81,
+                    "start": 41.48
+                },
+                {
+                    "end": 42.14,
+                    "word": "week,",
+                    "score": 0.83,
+                    "start": 41.82
+                },
+                {
+                    "end": 42.6,
+                    "word": "along",
+                    "score": 0.89,
+                    "start": 42.34
+                },
+                {
+                    "end": 42.74,
+                    "word": "with",
+                    "score": 0.81,
+                    "start": 42.6
+                },
+                {
+                    "end": 42.84,
+                    "word": "the",
+                    "score": 0.78,
+                    "start": 42.74
+                },
+                {
+                    "end": 43.2,
+                    "word": "caption,",
+                    "score": 0.72,
+                    "start": 42.84
+                },
+                {
+                    "end": 43.46,
+                    "word": "I",
+                    "score": 0,
+                    "start": 43.38
+                },
+                {
+                    "end": 43.58,
+                    "word": "am",
+                    "score": 0.53,
+                    "start": 43.46
+                },
+                {
+                    "end": 43.88,
+                    "word": "draining",
+                    "score": 0.76,
+                    "start": 43.58
+                },
+                {
+                    "end": 44.12,
+                    "word": "the",
+                    "score": 0.81,
+                    "start": 43.88
+                },
+                {
+                    "end": 44.61,
+                    "word": "swamp.",
+                    "score": 0.93,
+                    "start": 44.12
+                },
+                {
+                    "end": 44.95,
+                    "word": "Now,",
+                    "score": 0.48,
+                    "start": 44.81
+                },
+                {
+                    "end": 45.11,
+                    "word": "this",
+                    "score": 0.88,
+                    "start": 44.97
+                },
+                {
+                    "end": 45.25,
+                    "word": "is",
+                    "score": 0.89,
+                    "start": 45.11
+                },
+                {
+                    "end": 45.49,
+                    "word": "not",
+                    "score": 0.89,
+                    "start": 45.25
+                },
+                {
+                    "end": 45.65,
+                    "word": "the",
+                    "score": 0.81,
+                    "start": 45.49
+                },
+                {
+                    "end": 45.87,
+                    "word": "first",
+                    "score": 0.81,
+                    "start": 45.65
+                },
+                {
+                    "end": 46.07,
+                    "word": "time",
+                    "score": 0.8,
+                    "start": 45.87
+                },
+                {
+                    "end": 46.37,
+                    "word": "CNN",
+                    "score": 0.91,
+                    "start": 46.07
+                },
+                {
+                    "end": 46.61,
+                    "word": "has",
+                    "score": 0.9,
+                    "start": 46.37
+                },
+                {
+                    "end": 47.07,
+                    "word": "rejected",
+                    "score": 0.73,
+                    "start": 46.61
+                },
+                {
+                    "end": 47.33,
+                    "word": "a",
+                    "score": 1,
+                    "start": 47.07
+                },
+                {
+                    "end": 47.57,
+                    "word": "Trump",
+                    "score": 0.88,
+                    "start": 47.33
+                },
+                {
+                    "end": 48.07,
+                    "word": "campaign",
+                    "score": 0.82,
+                    "start": 47.57
+                },
+                {
+                    "end": 48.44,
+                    "word": "ad.",
+                    "score": 0.91,
+                    "start": 48.07
+                },
+                {
+                    "end": 48.85,
+                    "word": "Back",
+                    "score": 0.92,
+                    "start": 48.67
+                },
+                {
+                    "end": 48.95,
+                    "word": "in",
+                    "score": 0.91,
+                    "start": 48.85
+                },
+                {
+                    "end": 49.51,
+                    "word": "2017,",
+                    "score": 0.76,
+                    "start": 48.95
+                },
+                {
+                    "end": 49.81,
+                    "word": "the",
+                    "score": 0.8,
+                    "start": 49.75
+                },
+                {
+                    "end": 50.03,
+                    "word": "network",
+                    "score": 0.82,
+                    "start": 49.81
+                },
+                {
+                    "end": 50.49,
+                    "word": "refused",
+                    "score": 0.91,
+                    "start": 50.03
+                },
+                {
+                    "end": 50.71,
+                    "word": "to",
+                    "score": 0.9,
+                    "start": 50.49
+                },
+                {
+                    "end": 50.85,
+                    "word": "run",
+                    "score": 0.89,
+                    "start": 50.71
+                },
+                {
+                    "end": 50.97,
+                    "word": "a",
+                    "score": 1,
+                    "start": 50.85
+                },
+                {
+                    "end": 51.23,
+                    "word": "Trump",
+                    "score": 0.83,
+                    "start": 50.97
+                },
+                {
+                    "end": 51.59,
+                    "word": "-approved",
+                    "score": 0.82,
+                    "start": 51.23
+                },
+                {
+                    "end": 51.93,
+                    "word": "ad",
+                    "score": 0.92,
+                    "start": 51.59
+                },
+                {
+                    "end": 52.31,
+                    "word": "called",
+                    "score": 0.75,
+                    "start": 51.93
+                },
+                {
+                    "end": 52.73,
+                    "word": "Let",
+                    "score": 0.05,
+                    "start": 52.31
+                },
+                {
+                    "end": 53.09,
+                    "word": "President",
+                    "score": 0.86,
+                    "start": 52.73
+                },
+                {
+                    "end": 53.41,
+                    "word": "Trump",
+                    "score": 0.86,
+                    "start": 53.09
+                },
+                {
+                    "end": 53.59,
+                    "word": "Do",
+                    "score": 0.8,
+                    "start": 53.41
+                },
+                {
+                    "end": 53.81,
+                    "word": "His",
+                    "score": 0.86,
+                    "start": 53.59
+                },
+                {
+                    "end": 54.17,
+                    "word": "Job,",
+                    "score": 0.9,
+                    "start": 53.81
+                },
+                {
+                    "end": 54.6,
+                    "word": "which",
+                    "score": 0.91,
+                    "start": 54.4
+                },
+                {
+                    "end": 55.02,
+                    "word": "criticized",
+                    "score": 0.7,
+                    "start": 54.6
+                },
+                {
+                    "end": 55.22,
+                    "word": "the",
+                    "score": 0.82,
+                    "start": 55.02
+                },
+                {
+                    "end": 55.46,
+                    "word": "media",
+                    "score": 0.81,
+                    "start": 55.22
+                },
+                {
+                    "end": 55.78,
+                    "word": "and",
+                    "score": 0.72,
+                    "start": 55.46
+                },
+                {
+                    "end": 56.3,
+                    "word": "specifically",
+                    "score": 0.76,
+                    "start": 55.78
+                },
+                {
+                    "end": 56.7,
+                    "word": "called",
+                    "score": 0.79,
+                    "start": 56.3
+                },
+                {
+                    "end": 56.92,
+                    "word": "out",
+                    "score": 0.79,
+                    "start": 56.7
+                },
+                {
+                    "end": 57.18,
+                    "word": "Lemon",
+                    "score": 0.57,
+                    "start": 56.92
+                },
+                {
+                    "end": 57.5,
+                    "word": "as",
+                    "score": 0.61,
+                    "start": 57.18
+                },
+                {
+                    "end": 57.64,
+                    "word": "well",
+                    "score": 0.88,
+                    "start": 57.5
+                },
+                {
+                    "end": 57.76,
+                    "word": "as",
+                    "score": 0.91,
+                    "start": 57.64
+                },
+                {
+                    "end": 58.12,
+                    "word": "Anderson",
+                    "score": 0.58,
+                    "start": 57.76
+                },
+                {
+                    "end": 58.18,
+                    "word": ".",
+                    "score": 0.16,
+                    "start": 58.12
+                },
+                {
+                    "end": 58.69,
+                    "word": "To",
+                    "score": 0,
+                    "start": 58.41
+                },
+                {
+                    "end": 59.32,
+                    "word": "stay",
+                    "score": 0.93,
+                    "start": 59.14
+                },
+                {
+                    "end": 59.42,
+                    "word": "up",
+                    "score": 0.9,
+                    "start": 59.32
+                },
+                {
+                    "end": 59.52,
+                    "word": "to",
+                    "score": 0.76,
+                    "start": 59.42
+                },
+                {
+                    "end": 59.68,
+                    "word": "date",
+                    "score": 0.88,
+                    "start": 59.52
+                },
+                {
+                    "end": 59.8,
+                    "word": "on",
+                    "score": 0.9,
+                    "start": 59.68
+                },
+                {
+                    "end": 59.94,
+                    "word": "this",
+                    "score": 0.88,
+                    "start": 59.8
+                },
+                {
+                    "end": 60.24,
+                    "word": "story,",
+                    "score": 0.87,
+                    "start": 59.94
+                },
+                {
+                    "end": 60.4,
+                    "word": "head",
+                    "score": 0.47,
+                    "start": 60.24
+                },
+                {
+                    "end": 60.5,
+                    "word": "to",
+                    "score": 0.91,
+                    "start": 60.4
+                },
+                {
+                    "end": 60.86,
+                    "word": "thr",
+                    "score": 0.02,
+                    "start": 60.5
+                },
+                {
+                    "end": 61.72,
+                    "word": ".com,",
+                    "score": 0.96,
+                    "start": 60.86
+                },
+                {
+                    "end": 61.88,
+                    "word": "and",
+                    "score": 0.9,
+                    "start": 61.78
+                },
+                {
+                    "end": 62.08,
+                    "word": "until",
+                    "score": 0.82,
+                    "start": 61.88
+                },
+                {
+                    "end": 62.34,
+                    "word": "next",
+                    "score": 0.84,
+                    "start": 62.08
+                },
+                {
+                    "end": 62.54,
+                    "word": "time,",
+                    "score": 0.82,
+                    "start": 62.34
+                },
+                {
+                    "end": 62.66,
+                    "word": "for",
+                    "score": 0.9,
+                    "start": 62.56
+                },
+                {
+                    "end": 62.74,
+                    "word": "The",
+                    "score": 0.79,
+                    "start": 62.66
+                },
+                {
+                    "end": 62.98,
+                    "word": "Hollywood",
+                    "score": 0.76,
+                    "start": 62.74
+                },
+                {
+                    "end": 63.3,
+                    "word": "Reporter",
+                    "score": 0.82,
+                    "start": 62.98
+                },
+                {
+                    "end": 63.66,
+                    "word": "News,",
+                    "score": 0.81,
+                    "start": 63.3
+                },
+                {
+                    "end": 63.9,
+                    "word": "I'm",
+                    "score": 0.99,
+                    "start": 63.78
+                },
+                {
+                    "end": 64.04,
+                    "word": "Neha",
+                    "score": 0.9,
+                    "start": 63.9
+                },
+                {
+                    "end": 64.45,
+                    "word": "Joy.",
+                    "score": 0.86,
+                    "start": 64.04
+                }
+            ],
+            "speaker": "A",
+            "timestamp_end": 64450,
+            "timestamp_start": 320
+        }
+    ],
+    "speaker_map": {
+        "A": "SPEAKER A"
+    }
+}

--- a/src/rtasr/__main__.py
+++ b/src/rtasr/__main__.py
@@ -7,9 +7,9 @@ from rich.traceback import install
 from rich_argparse import RichHelpFormatter
 
 from rtasr.cli import (
-    BenchmarkASRCommand,
     DownloadDatasetCommand,
     ListItemsCommand,
+    TranscriptionASRCommand,
 )
 from rtasr.cli_messages import ascii_art
 
@@ -27,9 +27,9 @@ def main() -> None:
     commands_parser = parser.add_subparsers(dest="command")
 
     # Register subcommands
-    BenchmarkASRCommand.register_subcommand(commands_parser)
     DownloadDatasetCommand.register_subcommand(commands_parser)
     ListItemsCommand.register_subcommand(commands_parser)
+    TranscriptionASRCommand.register_subcommand(commands_parser)
 
     args = parser.parse_args()
 

--- a/src/rtasr/asr/providers.py
+++ b/src/rtasr/asr/providers.py
@@ -169,7 +169,8 @@ class ASRProvider(ABC):
                     elif status == TranscriptionStatus.FAILED:
                         task_tracking[audio_file_name]["status"] = status
                         print(
-                            rf"[bold red]\[{self.__class__.__name__}] -> {asr_output}[/bold"
+                            rf"[bold red]\[{self.__class__.__name__}] ->"
+                            rf" {asr_output}[/bold"
                             " red]"
                         )
                 except Exception as e:
@@ -218,7 +219,9 @@ class ASRProvider(ABC):
             asr_output_file_path.parent.mkdir(parents=True, exist_ok=True)
 
         async with aiofiles.open(asr_output_file_path, mode="w") as f:
-            await f.write(json.dumps(asr_output.model_dump(), indent=4, ensure_ascii=False))
+            await f.write(
+                json.dumps(asr_output.model_dump(), indent=4, ensure_ascii=False)
+            )
 
         rttm_file_path = (
             output_dir

--- a/src/rtasr/asr/providers.py
+++ b/src/rtasr/asr/providers.py
@@ -186,7 +186,7 @@ class ASRProvider(ABC):
         """
         _file_name = audio_file_name.split(".")[0]
         file_path = (
-            output_dir / f"{self.__class__.__name__.lower()}" / f"{_file_name}.txt"
+            output_dir / f"{self.__class__.__name__.lower()}" / "original" / f"{_file_name}.json"
         )
         if not file_path.parent.exists():
             file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -203,7 +203,7 @@ class ASRProvider(ABC):
         session: aiohttp.ClientSession,
     ) -> Tuple[str, TranscriptionStatus, dict]:
         """Run the ASR provider."""
-        raise NotImplementedError("The ASR provider must implement the `_run` method.")
+        raise NotImplementedError("The ASR provider must implement the `_launch` method.")
 
     @abstractmethod
     def result_to_rttm(self) -> None:
@@ -403,7 +403,7 @@ class Google(ASRProvider):
         options: dict,
         concurrency_limit: Union[int, None],
     ) -> None:
-        super().__init__(api_url, api_key)
+        super().__init__(api_url, api_key, concurrency_limit)
         self.options = GoogleOptions(**options)
 
     async def _launch(

--- a/src/rtasr/asr/providers.py
+++ b/src/rtasr/asr/providers.py
@@ -186,7 +186,10 @@ class ASRProvider(ABC):
         """
         _file_name = audio_file_name.split(".")[0]
         file_path = (
-            output_dir / f"{self.__class__.__name__.lower()}" / "original" / f"{_file_name}.json"
+            output_dir
+            / f"{self.__class__.__name__.lower()}"
+            / "original"
+            / f"{_file_name}.json"
         )
         if not file_path.parent.exists():
             file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -203,7 +206,9 @@ class ASRProvider(ABC):
         session: aiohttp.ClientSession,
     ) -> Tuple[str, TranscriptionStatus, dict]:
         """Run the ASR provider."""
-        raise NotImplementedError("The ASR provider must implement the `_launch` method.")
+        raise NotImplementedError(
+            "The ASR provider must implement the `_launch` method."
+        )
 
     @abstractmethod
     def result_to_rttm(self) -> None:

--- a/src/rtasr/asr/schemas.py
+++ b/src/rtasr/asr/schemas.py
@@ -1,0 +1,73 @@
+"""ASR providers schemas for handling request and response data."""
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel
+
+
+class ASROutput(BaseModel):
+    """ASR output schema."""
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "ASROutput":
+        """Create an ASROutput object from a JSON object."""
+        return cls(**data)
+
+
+class AssemblyAIOutput(ASROutput):
+    """AssemblyAI output schema."""
+
+
+class AwsOutput(ASROutput):
+    """AWS output schema."""
+
+
+class AzureOutput(ASROutput):
+    """Azure output schema."""
+
+
+class DeepgramOutput(ASROutput):
+    """Deepgram output schema."""
+
+
+class GoogleOutput(ASROutput):
+    """Google output schema."""
+
+
+class RevAIOutput(ASROutput):
+    """RevAI output schema."""
+
+
+class SpeechmaticsOutput(ASROutput):
+    """Speechmatics output schema."""
+
+
+class WordcabWord(BaseModel):
+    """Wordcab word schema."""
+
+    word: str
+    start: float
+    end: float
+    score: float
+
+
+class WordcabTranscript(BaseModel):
+    """Wordcab transcript schema."""
+
+    text: str
+    start: str
+    end: str
+    speaker: str
+    words: List[WordcabWord]
+    timestamp_end: int
+    timestamp_start: int
+
+
+class WordcabOutput(ASROutput):
+    """Wordcab output schema."""
+
+    transcript_id: str
+    job_id_set: List[str]
+    summary_id_set: List[str]
+    transcript: List[WordcabTranscript]
+    speaker_map: Dict[str, str]

--- a/src/rtasr/cli/__init__.py
+++ b/src/rtasr/cli/__init__.py
@@ -1,11 +1,11 @@
 """The CLI module regroups all the CLI related classes and functions."""
 
-from .benchmark_command import BenchmarkASRCommand
 from .download_command import DownloadDatasetCommand
 from .list_command import ListItemsCommand
+from .transcription_command import TranscriptionASRCommand
 
 __all__ = [
-    "BenchmarkASRCommand",
     "DownloadDatasetCommand",
     "ListItemsCommand",
+    "TranscriptionASRCommand",
 ]

--- a/src/rtasr/cli/transcription_command.py
+++ b/src/rtasr/cli/transcription_command.py
@@ -1,4 +1,4 @@
-"""The benchmark command."""
+"""The transcription command to run ASR providers against a dataset."""
 
 import argparse
 import asyncio
@@ -18,8 +18,8 @@ from rtasr.constants import DATASETS, PROVIDERS
 from rtasr.utils import create_live_panel, get_api_key, resolve_cache_dir
 
 
-def benchmark_asr_command_factory(args: argparse.Namespace):
-    return BenchmarkASRCommand(
+def transcription_asr_command_factory(args: argparse.Namespace):
+    return TranscriptionASRCommand(
         args.providers,
         args.dataset,
         args.split,
@@ -29,20 +29,20 @@ def benchmark_asr_command_factory(args: argparse.Namespace):
     )
 
 
-class BenchmarkASRCommand:
-    """Benchmark an ASR provider against a dataset."""
+class TranscriptionASRCommand:
+    """Launc transcription for one or multiple ASR providers against a dataset."""
 
     @staticmethod
     def register_subcommand(parser: argparse.ArgumentParser) -> None:
         subparser = parser.add_parser(
-            "benchmark",
-            help="Benchmark one or multiple ASR providers against a dataset.",
+            "transcription",
+            help="Launch transcription for one or multiple ASR providers against a dataset.",
         )
         subparser.add_argument(
             "-p",
             "--providers",
             help=(
-                "The ASR provider(s) to benchmark. You can specify multiple providers."
+                "The ASR provider(s) to call. You can specify multiple providers."
             ),
             required=True,
             type=str,
@@ -73,8 +73,8 @@ class BenchmarkASRCommand:
             "-o",
             "--output_dir",
             help=(
-                "Path where store the benchmark outputs. Defaults to"
-                " `~/.cache/rtasr/benchmark`."
+                "Path where store the transcription outputs. Defaults to"
+                " `~/.cache/rtasr/transcription`."
             ),
             required=False,
             default=None,
@@ -86,7 +86,7 @@ class BenchmarkASRCommand:
             required=False,
             action="store_false",
         )
-        subparser.set_defaults(func=benchmark_asr_command_factory)
+        subparser.set_defaults(func=transcription_asr_command_factory)
 
     def __init__(
         self,
@@ -214,13 +214,13 @@ class BenchmarkASRCommand:
                 )
 
             if self.output_dir is None:
-                output_dir = resolve_cache_dir() / "benchmark"
+                output_dir = resolve_cache_dir() / "transcription"
             else:
-                output_dir = Path(self.output_dir) / "benchmark"
+                output_dir = Path(self.output_dir) / "transcription"
 
-            benchmark_dir = output_dir / _dataset
-            if not benchmark_dir.exists():
-                benchmark_dir.mkdir(parents=True, exist_ok=True)
+            transcription_dir = output_dir / _dataset
+            if not transcription_dir.exists():
+                transcription_dir.mkdir(parents=True, exist_ok=True)
 
             engines: List[ASRProvider] = []
             for _provider in _providers:
@@ -251,13 +251,13 @@ class BenchmarkASRCommand:
 
             with Live(progress_group):
                 current_progress_task_id = current_progress.add_task(
-                    f"Benchmarking on the `{_dataset}` dataset"
+                    f"Running transcription over the `{_dataset}` dataset"
                 )
                 results = asyncio.run(
                     self._run(
                         engines,
                         verified_audio_filepaths,
-                        benchmark_dir,
+                        transcription_dir,
                         splits_progress,
                         step_progress,
                     )
@@ -266,10 +266,10 @@ class BenchmarkASRCommand:
                 current_progress.stop_task(current_progress_task_id)
                 current_progress.update(
                     current_progress_task_id,
-                    description="[bold green]Benchmarking finished.",
+                    description="[bold green]Transcriptions finished.",
                 )
 
-            print(f"Find the benchmark results in {benchmark_dir.resolve()}")
+            print(f"Find the transcription results in {transcription_dir.resolve()}")
             print("Results by provider: [green]completed[/green]|[red]failed[/red]")
 
             for result in results:

--- a/src/rtasr/cli/transcription_command.py
+++ b/src/rtasr/cli/transcription_command.py
@@ -36,14 +36,15 @@ class TranscriptionASRCommand:
     def register_subcommand(parser: argparse.ArgumentParser) -> None:
         subparser = parser.add_parser(
             "transcription",
-            help="Launch transcription for one or multiple ASR providers against a dataset.",
+            help=(
+                "Launch transcription for one or multiple ASR providers against a"
+                " dataset."
+            ),
         )
         subparser.add_argument(
             "-p",
             "--providers",
-            help=(
-                "The ASR provider(s) to call. You can specify multiple providers."
-            ),
+            help="The ASR provider(s) to call. You can specify multiple providers.",
             required=True,
             type=str,
             nargs="+",

--- a/src/rtasr/constants.py
+++ b/src/rtasr/constants.py
@@ -60,6 +60,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "https://api.assemblyai.com/v2",
                 "engine": "AssemblyAI",
+                "output": "AssemblyAIOutput",
                 "concurrency_limit": 5,
                 "options": {
                     "speaker_labels": True,
@@ -72,6 +73,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "",
                 "engine": "Aws",
+                "output": "AwsOutput",
             },
         ),
         (
@@ -79,6 +81,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "",
                 "engine": "Azure",
+                "output": "AzureOutput",
             },
         ),
         (
@@ -86,6 +89,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "https://api.deepgram.com/v1/listen",
                 "engine": "Deepgram",
+                "output": "DeepgramOutput",
                 "options": {
                     "diarize": True,
                     "model": "nova",
@@ -99,6 +103,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "",
                 "engine": "Google",
+                "output": "GoogleOutput",
             },
         ),
         (
@@ -106,6 +111,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "https://api.rev.ai/speechtotext/v1",
                 "engine": "RevAI",
+                "output": "RevAIOutput",
                 "concurrency_limit": 5,
                 "options": {
                     "remove_disfluencies": False,
@@ -121,6 +127,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "https://asr.api.speechmatics.com/v2",
                 "engine": "Speechmatics",
+                "output": "SpeechmaticsOutput",
                 "options": {
                     "type": "transcription",
                     "transcription_config": {
@@ -136,6 +143,7 @@ PROVIDERS = OrderedDict(
             {
                 "url": "https://wordcab.com/api/v1",
                 "engine": "Wordcab",
+                "output": "WordcabOutput",
                 "options": {
                     "alignment": False,
                     "diarize": True,


### PR DESCRIPTION
## ✨ Features

* Adds ASROutput for each ASR provider to manipulate transcription outputs easily.
* Rename everything from `benchmark` to `transcription` for clarity.
* Update the `_save_result` method to `_save_results` to also handle rttm file save.
* Add `result_to_rttm` for Wordcab.
* Add transcription data samples for all implemented ASR providers.

## 🔗 Linked Issue/s

#29 

## 🧪 Tests

- [ ] Did you implement unit tests if required?

No tests were added, only local testing.